### PR TITLE
DTO 상세 설명을 위한 추가적인 Swagger 어노테이션 작성

### DIFF
--- a/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogConditionRequest.java
+++ b/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogConditionRequest.java
@@ -21,9 +21,13 @@ public class SpeakingLogConditionRequest {
 	 *  - (0[1-9]|[12][0-9]|3[01]) : 0과 1~9 또는 1,2와 0~9 또는 3과 0,1로 day 2자 표현
 	 */
 
+	@Schema(type = "String", description = "생년월일, NOT NULL", example = "YYYYMMDD")
 	public static final String YYYYMMDD = "(19|20)\\d{2}(0[1-9]|1[012])(0[1-9]|[12][0-9]|3[01])";
 
+	@Schema(enumAsRef = true, description = "스피킹 로그 조회 타입, NOT NULL")
 	private final SpeakingLogType type;
+
+	@Schema(type = "date", description = "날짜, NOT NULL")
 	private final LocalDate date;
 
 	public SpeakingLogConditionRequest(String type, String date) {

--- a/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogConditionRequest.java
+++ b/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogConditionRequest.java
@@ -2,12 +2,12 @@ package com.example.be.core.application.dto.request;
 
 import com.example.be.common.exception.speakinglog.InvalidSpeakingLogDateException;
 import com.example.be.core.domain.SpeakingLogType;
-import java.time.LocalDate;
-import java.util.regex.Pattern;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.ToString;
+
+import java.time.LocalDate;
+import java.util.regex.Pattern;
 
 @ToString
 @Getter
@@ -21,7 +21,6 @@ public class SpeakingLogConditionRequest {
 	 *  - (0[1-9]|[12][0-9]|3[01]) : 0과 1~9 또는 1,2와 0~9 또는 3과 0,1로 day 2자 표현
 	 */
 
-	@Schema(type = "String", description = "생년월일, NOT NULL", example = "YYYYMMDD")
 	public static final String YYYYMMDD = "(19|20)\\d{2}(0[1-9]|1[012])(0[1-9]|[12][0-9]|3[01])";
 
 	@Schema(enumAsRef = true, description = "스피킹 로그 조회 타입, NOT NULL")

--- a/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogConditionRequest.java
+++ b/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogConditionRequest.java
@@ -4,6 +4,8 @@ import com.example.be.common.exception.speakinglog.InvalidSpeakingLogDateExcepti
 import com.example.be.core.domain.SpeakingLogType;
 import java.time.LocalDate;
 import java.util.regex.Pattern;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.ToString;
 

--- a/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogModifyRequest.java
+++ b/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogModifyRequest.java
@@ -4,11 +4,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public class SpeakingLogModifyRequest {
 
-	@Schema(type = "String", description = "제목, NOT NULL")
+	@Schema(type = "String", description = "변경할 제목, NOT NULL")
 	private String title;
-	@Schema(type = "String", description = "음성 녹음 URL, NOT NULL")
+
+	@Schema(type = "String", description = "변경할 음성 녹음 URL, NOT NULL")
 	private String voiceRecord;
-	@Schema(type = "String", description = "음성 텍스트 URL, NOT NULL")
+
+	@Schema(type = "String", description = "변경할 음성 텍스트 URL, NOT NULL")
 	private String voiceText;
 
 	private SpeakingLogModifyRequest() {}

--- a/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogModifyRequest.java
+++ b/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogModifyRequest.java
@@ -1,9 +1,14 @@
 package com.example.be.core.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public class SpeakingLogModifyRequest {
 
+	@Schema(type = "String", description = "제목, NOT NULL")
 	private String title;
+	@Schema(type = "String", description = "음성 녹음 URL, NOT NULL")
 	private String voiceRecord;
+	@Schema(type = "String", description = "음성 텍스트 URL, NOT NULL")
 	private String voiceText;
 
 	private SpeakingLogModifyRequest() {}

--- a/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogRequest.java
+++ b/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogRequest.java
@@ -1,13 +1,17 @@
 package com.example.be.core.application.dto.request;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class SpeakingLogRequest {
 
+    @Schema(type = "String", description = "제목, NOT NULL")
     private String title;
+    @Schema(type = "String", description = "음성 녹음 URL, NOT NULL")
     private String voiceRecord;
+    @Schema(type = "String", description = "음성 텍스트 URL, NOT NULL")
     private String voiceText;
 
     private SpeakingLogRequest() {}

--- a/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogRequest.java
+++ b/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogRequest.java
@@ -9,8 +9,10 @@ public class SpeakingLogRequest {
 
     @Schema(type = "String", description = "제목, NOT NULL")
     private String title;
+
     @Schema(type = "String", description = "음성 녹음 URL, NOT NULL")
     private String voiceRecord;
+
     @Schema(type = "String", description = "음성 텍스트 URL, NOT NULL")
     private String voiceText;
 

--- a/be/src/main/java/com/example/be/core/application/dto/response/CommentResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/CommentResponse.java
@@ -3,22 +3,28 @@ package com.example.be.core.application.dto.response;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class CommentResponse {
 
+	@Schema(type = "Long", description = "댓글 ID, NOT NULL")
 	@NotNull
 	@Positive
 	private final Long commentId;
 
+	@Schema(type = "Long", description = "멤버 ID, NOT NULL")
 	@NotNull
 	@Positive
 	private final Long memberId;
 
+	@Schema(type = "String", description = "멤버 닉네임, NOT NULL")
 	@NotBlank
 	private final String nickname;
 
+	@Schema(type = "String", description = "댓글 내용, NOT NULL")
 	@NotBlank
 	private final String content;
 

--- a/be/src/main/java/com/example/be/core/application/dto/response/CommentResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/CommentResponse.java
@@ -1,11 +1,11 @@
 package com.example.be.core.application.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
-
-import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
 
 @Getter
 public class CommentResponse {

--- a/be/src/main/java/com/example/be/core/application/dto/response/QuestionResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/QuestionResponse.java
@@ -1,9 +1,9 @@
 package com.example.be.core.application.dto.response;
 
-import javax.validation.constraints.NotBlank;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
 
 @Getter
 public class QuestionResponse {

--- a/be/src/main/java/com/example/be/core/application/dto/response/QuestionResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/QuestionResponse.java
@@ -1,18 +1,25 @@
 package com.example.be.core.application.dto.response;
 
 import javax.validation.constraints.NotBlank;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
+
+@Schema(description = "오늘의 문장 Response")
 @Getter
 public class QuestionResponse {
 
+    @Schema(type = "String", description = "문장 주제, NOT NULL")
     @NotBlank
     private final String title;
 
     @NotBlank
+    @Schema(type = "String", description = "음성 녹음 URL, NOT NULL")
     private final String voidRecord;
 
     @NotBlank
+    @Schema(type = "String", description = "음성 텍스트 URL, NOT NULL")
     private final String voiceText;
 
     public QuestionResponse(String title, String voidRecord, String voiceText) {

--- a/be/src/main/java/com/example/be/core/application/dto/response/QuestionResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/QuestionResponse.java
@@ -5,8 +5,6 @@ import javax.validation.constraints.NotBlank;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
-
-@Schema(description = "오늘의 문장 Response")
 @Getter
 public class QuestionResponse {
 

--- a/be/src/main/java/com/example/be/core/application/dto/response/SpeakingLogDetailResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/SpeakingLogDetailResponse.java
@@ -11,29 +11,24 @@ import java.util.List;
 @Getter
 public class SpeakingLogDetailResponse {
 
-	@Schema(type = "Long",
-			description = "멤버 ID, NOT NULL")
+	@Schema(type = "Long", description = "멤버 ID, NOT NULL")
 	@NotNull
 	@Positive
 	private final Long memberId;
 
-	@Schema(type = "String",
-			description = "제목, NOT NULL")
+	@Schema(type = "String", description = "제목, NOT NULL")
 	@NotBlank
 	private final String title;
 
-	@Schema(type = "String",
-			description = "음성 녹음 URL, NOT NULL")
+	@Schema(type = "String", description = "음성 녹음 URL, NOT NULL")
 	@NotBlank
 	private final String voiceRecord;
 
-	@Schema(type = "String",
-			description = "음성 텍스트 URL, NOT NULL")
+	@Schema(type = "String", description = "음성 텍스트 URL, NOT NULL")
 	@NotBlank
 	private final String voiceText;
 
-	@Schema(type = "Int",
-			description = "좋아요 개수, NOT NULL")
+	@Schema(type = "Int", description = "좋아요 개수, NOT NULL")
 	@NotNull
 	private final Integer likeCount;
 
@@ -44,6 +39,7 @@ public class SpeakingLogDetailResponse {
 	@Schema(type = "Boolean", description = "좋아요 여부, NOT NULL")
 	@NotNull
 	private final Boolean isLiked;
+
 	@Schema(type = "List<Comment>", description = "댓글 리스트, NULLABLE")
 	private final List<CommentResponse> comments;
 

--- a/be/src/main/java/com/example/be/core/application/dto/response/SpeakingLogDetailResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/SpeakingLogDetailResponse.java
@@ -8,7 +8,6 @@ import javax.validation.constraints.Positive;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
-@Schema
 @Getter
 public class SpeakingLogDetailResponse {
 

--- a/be/src/main/java/com/example/be/core/application/dto/response/SpeakingLogDetailResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/SpeakingLogDetailResponse.java
@@ -4,32 +4,42 @@ import java.util.List;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
+@Schema
 @Getter
 public class SpeakingLogDetailResponse {
 
+	@Schema(type = "Long", description = "멤버 ID, NOT NULL")
 	@NotNull
 	@Positive
 	private final Long memberId;
 
+	@Schema(type = "String", description = "제목, NOT NULL")
 	@NotBlank
 	private final String title;
 
+	@Schema(type = "String", description = "음성 녹음 URL, NOT NULL")
 	@NotBlank
 	private final String voiceRecord;
 
+	@Schema(type = "String", description = "음성 텍스트 URL, NOT NULL")
 	@NotBlank
 	private final String voiceText;
 
+	@Schema(type = "Int", description = "좋아요 개수, NOT NULL")
 	@NotNull
 	private final Integer likeCount;
 
 	@NotNull
 	private final Integer commentCount;
 
+	@Schema(type = "Boolean", description = "좋아요 여부, NOT NULL")
 	@NotNull
 	private final Boolean isLiked;
+	@Schema(type = "List<Comment>", description = "댓글 리스트, NULLABLE")
 	private final List<CommentResponse> comments;
 
 	public SpeakingLogDetailResponse(Long memberId, String title, String voiceRecord, String voiceText,

--- a/be/src/main/java/com/example/be/core/application/dto/response/SpeakingLogDetailResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/SpeakingLogDetailResponse.java
@@ -1,37 +1,43 @@
 package com.example.be.core.application.dto.response;
 
-import java.util.List;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
-
-import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
+import java.util.List;
 
 @Getter
 public class SpeakingLogDetailResponse {
 
-	@Schema(type = "Long", description = "멤버 ID, NOT NULL")
+	@Schema(type = "Long",
+			description = "멤버 ID, NOT NULL")
 	@NotNull
 	@Positive
 	private final Long memberId;
 
-	@Schema(type = "String", description = "제목, NOT NULL")
+	@Schema(type = "String",
+			description = "제목, NOT NULL")
 	@NotBlank
 	private final String title;
 
-	@Schema(type = "String", description = "음성 녹음 URL, NOT NULL")
+	@Schema(type = "String",
+			description = "음성 녹음 URL, NOT NULL")
 	@NotBlank
 	private final String voiceRecord;
 
-	@Schema(type = "String", description = "음성 텍스트 URL, NOT NULL")
+	@Schema(type = "String",
+			description = "음성 텍스트 URL, NOT NULL")
 	@NotBlank
 	private final String voiceText;
 
-	@Schema(type = "Int", description = "좋아요 개수, NOT NULL")
+	@Schema(type = "Int",
+			description = "좋아요 개수, NOT NULL")
 	@NotNull
 	private final Integer likeCount;
 
+	@Schema(type = "Int", description = "댓글 개수, NOT NULL")
 	@NotNull
 	private final Integer commentCount;
 

--- a/be/src/main/java/com/example/be/core/application/dto/response/SpeakingLogResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/SpeakingLogResponse.java
@@ -3,32 +3,43 @@ package com.example.be.core.application.dto.response;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class SpeakingLogResponse {
 
+	@Schema(type = "Long", description = "스피킹 로그 ID, NOT NULL")
 	@NotNull
 	@Positive
 	private final Long speakingLogId;
+
+	@Schema(type = "String", description = "제목, NOT NULL")
 	@NotBlank
 	private final String title;
 
+	@Schema(type = "String", description = "음성 녹음 URL, NOT NULL")
 	@NotBlank
 	private final String voiceRecord;
 
+	@Schema(type = "Int", description = "좋아요 개수, NOT NULL")
 	@NotNull
 	private final Integer likeCount;
 
+	@Schema(type = "Int", description = "댓글 개수, NOT NULL")
 	@NotNull
 	private final Integer commentCount;
 
+	@Schema(type = "Boolean", description = "좋아요 여부, NOT NULL")
 	@NotNull
 	private final Boolean isLiked;
 
+	@Schema(type = "String", description = "프로필 이미지, NOT NULL")
 	@NotNull
 	private final String profileImage;
 
+	@Schema(type = "Long", description = "멤버 ID, NOT NULL")
 	@NotNull
 	@Positive
 	private final Long memberId;

--- a/be/src/main/java/com/example/be/core/application/dto/response/SpeakingLogResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/SpeakingLogResponse.java
@@ -1,11 +1,11 @@
 package com.example.be.core.application.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
-
-import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
 
 @Getter
 public class SpeakingLogResponse {

--- a/be/src/main/java/com/example/be/core/application/dto/response/SpeakingLogsResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/SpeakingLogsResponse.java
@@ -3,11 +3,14 @@ package com.example.be.core.application.dto.response;
 import com.example.be.core.domain.SpeakingLogType;
 import java.util.List;
 import javax.validation.constraints.NotNull;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class SpeakingLogsResponse {
 
+	@Schema(enumAsRef = true, description = "스피킹 로그 조회 타입, NOT NULL")
 	@NotNull
 	private final SpeakingLogType type;
 	private final List<SpeakingLogResponse> speakingLogResponses;

--- a/be/src/main/java/com/example/be/core/application/dto/response/SpeakingLogsResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/SpeakingLogsResponse.java
@@ -1,11 +1,11 @@
 package com.example.be.core.application.dto.response;
 
 import com.example.be.core.domain.SpeakingLogType;
-import java.util.List;
-import javax.validation.constraints.NotNull;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
 
 @Getter
 public class SpeakingLogsResponse {
@@ -13,7 +13,9 @@ public class SpeakingLogsResponse {
 	@Schema(enumAsRef = true, description = "스피킹 로그 조회 타입, NOT NULL")
 	@NotNull
 	private final SpeakingLogType type;
+
 	private final List<SpeakingLogResponse> speakingLogResponses;
+
 	public SpeakingLogsResponse(SpeakingLogType type,
 		List<SpeakingLogResponse> speakingLogResponses) {
 		this.type = type;

--- a/be/src/main/java/com/example/be/core/web/QuestionController.java
+++ b/be/src/main/java/com/example/be/core/web/QuestionController.java
@@ -6,6 +6,7 @@ import com.example.be.common.response.BaseResponse;
 import com.example.be.core.application.QuestionService;
 import com.example.be.core.application.dto.response.QuestionResponse;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,7 +20,7 @@ public class QuestionController {
     public QuestionController(QuestionService questionService) {
         this.questionService = questionService;
     }
-
+    
     @GetMapping
     @ApiOperation(value = "오늘의 문장 조회입니다.")
     public BaseResponse<QuestionResponse> find() {

--- a/be/src/main/java/com/example/be/core/web/QuestionController.java
+++ b/be/src/main/java/com/example/be/core/web/QuestionController.java
@@ -20,7 +20,7 @@ public class QuestionController {
     public QuestionController(QuestionService questionService) {
         this.questionService = questionService;
     }
-    
+
     @GetMapping
     @ApiOperation(value = "오늘의 문장 조회입니다.")
     public BaseResponse<QuestionResponse> find() {

--- a/be/src/main/java/com/example/be/core/web/QuestionController.java
+++ b/be/src/main/java/com/example/be/core/web/QuestionController.java
@@ -8,7 +8,6 @@ import com.example.be.core.application.dto.response.QuestionResponse;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController

--- a/be/src/main/java/com/example/be/core/web/SpeakingLogController.java
+++ b/be/src/main/java/com/example/be/core/web/SpeakingLogController.java
@@ -70,7 +70,6 @@ public class SpeakingLogController {
 	@ApiOperation(value = "스피킹 로그 생성입니다.")
 	public BaseResponse<SpeakingLogDetailResponse> create(
 		@RequestBody final SpeakingLogRequest speakingLogRequest) {
-
 		SpeakingLogDetailResponse response = speakingLogService.create(speakingLogRequest);
 		return new BaseResponse<>(CREATE_SPEAKING_LOG_SUCCESS, response);
 	}

--- a/be/src/main/java/com/example/be/core/web/SpeakingLogController.java
+++ b/be/src/main/java/com/example/be/core/web/SpeakingLogController.java
@@ -15,6 +15,8 @@ import com.example.be.core.application.dto.response.SpeakingLogsResponse;
 import com.example.be.core.domain.SpeakingLogType;
 import io.swagger.annotations.ApiOperation;
 import java.time.LocalDate;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;


### PR DESCRIPTION
### ❗️ 이슈번호 

Closes #13 

### 📝 구현 내용

![image](https://user-images.githubusercontent.com/95534831/213473275-e6b2b369-6a15-4b7b-8159-daa49b51b6a6.png)

이런식으로 각 필드에 타입과 설명, NULL 허용 여부 등을 작성했습니다. 

지금 설명과 NULL 허용 여부가 description 속성 값에 한번에 들어가는데, 
nullable = false 같은 속성이 있긴 했지만 스웨거 ui 상으로 표시가 되지 않아 묶어서 표시했습니다.

각 api의 request, response에서 schema를 눌러 확인할 수 있습니다.
![image](https://user-images.githubusercontent.com/95534831/213475373-3d29fa0d-7536-45a4-ac4a-d217683d0f52.png)
![image](https://user-images.githubusercontent.com/95534831/213476014-10bfcc09-6d50-41f8-98c7-a7268a728238.png)

#### 📝 수정 사항!
- 명세에 들어가지 않는 필드 schema 삭제
- 가독성을 위한 schema 어노테이션 속성값 줄바꿈
- api 특징에 따른 필드 값 설명 (아직 바꿀게 로그 수정 API 밖에 없는 것 같아 수정 사항이 별로 없습니다.)
![image](https://user-images.githubusercontent.com/95534831/213594481-c1ecfcd8-e104-4856-adae-8c9923e86162.png)






