### PR TITLE
도메인 공통 정보를 담는 Base Entity 생성

### DIFF
--- a/be/src/main/java/com/example/be/common/config/JpaAuditingConfiguration.java
+++ b/be/src/main/java/com/example/be/common/config/JpaAuditingConfiguration.java
@@ -1,0 +1,10 @@
+package com.example.be.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+
+}

--- a/be/src/main/java/com/example/be/common/config/WebConfig.java
+++ b/be/src/main/java/com/example/be/common/config/WebConfig.java
@@ -1,7 +1,6 @@
 package com.example.be.common.config;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.format.FormatterRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration

--- a/be/src/main/java/com/example/be/core/domain/BaseEntity.java
+++ b/be/src/main/java/com/example/be/core/domain/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.example.be.core.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private Boolean deleted = Boolean.FALSE;
+}


### PR DESCRIPTION
### ❗️ 이슈 번호

Closes #10

<br><br>

### 📝 구현 내용

- 도메인 공통 정보를 담는 Base Entity 생성 완료
- JPA Auditing 추가를 통해 변경 감지를 하여 createdAt, modifiedAt이 자동으로 들어가도록 설정
