### PR TITLE
SpeakingLogController의 Test들이 공통적으로 가지는 로직 처리

### DIFF
--- a/be/src/test/java/com/example/be/core/web/speakinglog/InitSpeakingLogControllerTest.java
+++ b/be/src/test/java/com/example/be/core/web/speakinglog/InitSpeakingLogControllerTest.java
@@ -1,0 +1,33 @@
+package com.example.be.core.web.speakinglog;
+
+import com.example.be.core.application.SpeakingLogService;
+import com.example.be.core.web.SpeakingLogController;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@WebMvcTest(SpeakingLogController.class)
+public abstract class InitSpeakingLogControllerTest {
+
+	@Autowired
+	protected MockMvc mockMvc;
+
+	@MockBean
+	protected SpeakingLogService speakingLogService;
+
+	@Autowired
+	protected ObjectMapper objectMapper;
+
+	@BeforeEach
+	public void init(WebApplicationContext wc) {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(wc)
+			.addFilter(new CharacterEncodingFilter("UTF-8", true))
+			.build();
+	}
+}

--- a/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerCreateTest.java
+++ b/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerCreateTest.java
@@ -9,44 +9,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.be.common.response.BaseResponse;
-import com.example.be.core.application.SpeakingLogService;
 import com.example.be.core.application.dto.request.SpeakingLogRequest;
 import com.example.be.core.application.dto.response.SpeakingLogDetailResponse;
-import com.example.be.core.web.SpeakingLogController;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.CharacterEncodingFilter;
-
-@WebMvcTest(SpeakingLogController.class)
-public class SpeakingLogControllerCreateTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private SpeakingLogService speakingLogService;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @BeforeEach
-    public void init(WebApplicationContext wc) {
-        this.mockMvc = MockMvcBuilders.webAppContextSetup(wc)
-                .addFilter(new CharacterEncodingFilter("UTF-8", true))
-                .build();
-    }
+public class SpeakingLogControllerCreateTest extends InitSpeakingLogControllerTest{
 
     @Nested
     @DisplayName("Speaking Log 생성할 때")

--- a/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerDeleteTest.java
+++ b/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerDeleteTest.java
@@ -26,25 +26,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-
-@WebMvcTest(SpeakingLogController.class)
-public class SpeakingLogControllerDeleteTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private SpeakingLogService speakingLogService;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @BeforeEach
-    public void init(WebApplicationContext wc) {
-        this.mockMvc = MockMvcBuilders.webAppContextSetup(wc)
-                .addFilter(new CharacterEncodingFilter("UTF-8", true))
-                .build();
-    }
+public class SpeakingLogControllerDeleteTest extends InitSpeakingLogControllerTest{
 
     @Nested
     @DisplayName("Speaking Log 삭제할 때")

--- a/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerDetailFindTest.java
+++ b/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerDetailFindTest.java
@@ -28,24 +28,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-@WebMvcTest(SpeakingLogController.class)
-public class SpeakingLogControllerDetailFindTest {
-
-	@Autowired
-	private MockMvc mockMvc;
-
-	@MockBean
-	private SpeakingLogService speakingLogService;
-
-	@Autowired
-	private ObjectMapper objectMapper;
-
-	@BeforeEach
-	public void init(WebApplicationContext wc) {
-		this.mockMvc = MockMvcBuilders.webAppContextSetup(wc)
-			.addFilter(new CharacterEncodingFilter("UTF-8", true))
-			.build();
-	}
+public class SpeakingLogControllerDetailFindTest extends InitSpeakingLogControllerTest{
 
 	@Nested
 	@DisplayName("Speaking Log 상세 조회할 때")

--- a/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerFindByTypeTest.java
+++ b/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerFindByTypeTest.java
@@ -31,24 +31,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-@WebMvcTest(SpeakingLogController.class)
-class SpeakingLogControllerFindByTypeTest {
+class SpeakingLogControllerFindByTypeTest extends InitSpeakingLogControllerTest{
 
-	@Autowired
-	private MockMvc mockMvc;
-
-	@MockBean
-	private SpeakingLogService speakingLogService;
-
-	@Autowired
-	private ObjectMapper objectMapper;
-
-	@BeforeEach
-	public void init(WebApplicationContext wc) {
-		this.mockMvc = MockMvcBuilders.webAppContextSetup(wc)
-			.addFilter(new CharacterEncodingFilter("UTF-8", true))
-			.build();
-	}
 	@Nested
 	@DisplayName("Speaking Log를 조회할 때")
 	class RetrieveTest {

--- a/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerModifyTest.java
+++ b/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerModifyTest.java
@@ -29,24 +29,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-@WebMvcTest(SpeakingLogController.class)
-public class SpeakingLogControllerModifyTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private SpeakingLogService speakingLogService;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @BeforeEach
-    public void init(WebApplicationContext wc) {
-        this.mockMvc = MockMvcBuilders.webAppContextSetup(wc)
-            .addFilter(new CharacterEncodingFilter("UTF-8", true))
-            .build();
-    }
+public class SpeakingLogControllerModifyTest extends InitSpeakingLogControllerTest{
 
     @Nested
     @DisplayName("Speaking Log 수정할 때")


### PR DESCRIPTION
### ❗️ 이슈 번호

Closes #30

<br><br>

### 📝 구현 내용

- InitSpeakingLogController를 작성하여 공통 필드, 메서드를 분리
<img width="815" alt="image" src="https://user-images.githubusercontent.com/67811880/213666649-879a8ef4-8897-477d-a9df-f0904cc0f665.png">

<br><br>

### 💡 참고 자료

<img width="1133" alt="image" src="https://user-images.githubusercontent.com/67811880/213666336-d7d581a6-5a53-4222-be7a-faab127b5106.png">
