### PR TITLE
SpeakingLog 상세 조회 관련 서비스 로직 작성

### DIFF
--- a/be/src/main/java/com/example/be/common/exception/ErrorCodeAndMessages.java
+++ b/be/src/main/java/com/example/be/common/exception/ErrorCodeAndMessages.java
@@ -8,11 +8,16 @@ import lombok.ToString;
 @Getter
 public enum ErrorCodeAndMessages implements CodeAndMessages {
 
-	/*
-	400 Bad Request
+	/**
+	 * 400 Bad Request
 	 */
 	SPEAKING_LOG_TYPE_ERROR("E-BR001", "올바르지 않은 타입 형식입니다. ALL, MY, MATE 중 하나여야 합니다."),
-	SPEAKING_LOG_DATE_FORMAT_ERROR("E-BR002", "올바르지 않은 날짜 형식입니다. yyyyMMdd 형식이어야 합니다.")
+	SPEAKING_LOG_DATE_FORMAT_ERROR("E-BR002", "올바르지 않은 날짜 형식입니다. yyyyMMdd 형식이어야 합니다."),
+
+	/**
+	 * 404 Not Found
+	 */
+	SPEAKING_LOG_ID_NOT_FOUND_ERROR("E-NF001", "스피킹 로그 아이디를 찾을 수 없습니다."),
 	;
 
 	private final String code;

--- a/be/src/main/java/com/example/be/common/exception/speakinglog/NotFoundSpeakingLogIdException.java
+++ b/be/src/main/java/com/example/be/common/exception/speakinglog/NotFoundSpeakingLogIdException.java
@@ -1,0 +1,11 @@
+package com.example.be.common.exception.speakinglog;
+
+import com.example.be.common.exception.BaseException;
+import com.example.be.common.exception.ErrorCodeAndMessages;
+
+public class NotFoundSpeakingLogIdException extends BaseException {
+
+	public NotFoundSpeakingLogIdException() {
+		super(ErrorCodeAndMessages.SPEAKING_LOG_ID_NOT_FOUND_ERROR);
+	}
+}

--- a/be/src/main/java/com/example/be/core/application/SpeakingLogService.java
+++ b/be/src/main/java/com/example/be/core/application/SpeakingLogService.java
@@ -1,20 +1,45 @@
 package com.example.be.core.application;
 
+import com.example.be.common.exception.speakinglog.NotFoundSpeakingLogIdException;
 import com.example.be.core.application.dto.request.SpeakingLogConditionRequest;
 import com.example.be.core.application.dto.request.SpeakingLogModifyRequest;
 import com.example.be.core.application.dto.request.SpeakingLogRequest;
+import com.example.be.core.application.dto.response.CommentResponse;
 import com.example.be.core.application.dto.response.SpeakingLogDetailResponse;
 import com.example.be.core.application.dto.response.SpeakingLogsResponse;
-import com.example.be.core.domain.SpeakingLogType;
-import java.time.LocalDate;
+import com.example.be.core.domain.speakinglog.Favorite;
+import com.example.be.core.domain.speakinglog.SpeakingLog;
+import com.example.be.core.repository.speakinglog.CommentRepository;
+import com.example.be.core.repository.speakinglog.FavoriteRepository;
+import com.example.be.core.repository.speakinglog.SpeakingLogRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
-@Transactional(readOnly = true)
 @Service
+@Transactional(readOnly = true)
 public class SpeakingLogService {
+
+	private final SpeakingLogRepository speakingLogRepository;
+	private final FavoriteRepository favoriteRepository;
+	private final CommentRepository commentRepository;
+
+	public SpeakingLogService(SpeakingLogRepository speakingLogRepository,
+		FavoriteRepository favoriteRepository, CommentRepository commentRepository) {
+		this.speakingLogRepository = speakingLogRepository;
+		this.favoriteRepository = favoriteRepository;
+		this.commentRepository = commentRepository;
+	}
+
+	@Transactional
+	public SpeakingLogDetailResponse create(SpeakingLogRequest speakingLogRequest) {
+		log.debug("speakingLogRequest = {}", speakingLogRequest);
+		return null;
+	}
 
 	public SpeakingLogsResponse find(SpeakingLogConditionRequest speakingLogConditionRequest) {
 		log.debug(speakingLogConditionRequest.toString());
@@ -22,21 +47,42 @@ public class SpeakingLogService {
 	}
 
 	public SpeakingLogDetailResponse findById(Long speakingLogId) {
-		log.debug("SpeakingLogId = {}", speakingLogId);
-		return null;
+		log.debug("[스피킹 로그 상세 조회] SpeakingLogId = {}", speakingLogId);
+
+		SpeakingLog speakingLog = speakingLogRepository.findById(speakingLogId)
+			.orElseThrow(NotFoundSpeakingLogIdException::new);
+
+		// 임시 (아직 로그인 구현 X)
+		Long loginMemberId = 1L;
+
+		Optional<Favorite> favoriteOfLoginMember = favoriteRepository.findByMemberIdAndSpeakingLog(loginMemberId, speakingLog);
+
+		return new SpeakingLogDetailResponse(
+			speakingLog.getMember().getId(),
+			speakingLog.getTitle(),
+			speakingLog.getVoiceRecord(),
+			speakingLog.getVoiceText(),
+			favoriteRepository.countBySpeakingLogId(speakingLogId),
+			favoriteOfLoginMember.isPresent(),
+			getCommentResponses(speakingLogId)
+		);
 	}
 
-	public void delete(Long speakingLogId) {
-		log.debug("SpeakingLogId = {}", speakingLogId);
+	private List<CommentResponse> getCommentResponses(Long speakingLogId) {
+		return commentRepository.findAllBySpeakingLogId(speakingLogId)
+			.stream()
+			.map(CommentResponse::from)
+			.collect(Collectors.toList());
 	}
 
+	@Transactional
 	public SpeakingLogDetailResponse modify(Long speakingLogId, SpeakingLogModifyRequest speakingLogModifyRequest) {
 		log.debug("SpeakingLogId = {}, speakingLogRequest = {}", speakingLogId, speakingLogModifyRequest);
 		return null;
 	}
 
-	public SpeakingLogDetailResponse create(SpeakingLogRequest speakingLogRequest) {
-		log.debug("speakingLogRequest = {}", speakingLogRequest);
-		return null;
+	@Transactional
+	public void delete(Long speakingLogId) {
+		log.debug("SpeakingLogId = {}", speakingLogId);
 	}
 }

--- a/be/src/main/java/com/example/be/core/application/SpeakingLogService.java
+++ b/be/src/main/java/com/example/be/core/application/SpeakingLogService.java
@@ -46,14 +46,13 @@ public class SpeakingLogService {
 		return null;
 	}
 
-	public SpeakingLogDetailResponse findById(Long speakingLogId) {
+	public SpeakingLogDetailResponse findById(Long speakingLogId, Long loginMemberId) {
 		log.debug("[스피킹 로그 상세 조회] SpeakingLogId = {}", speakingLogId);
 
 		SpeakingLog speakingLog = speakingLogRepository.findById(speakingLogId)
 			.orElseThrow(NotFoundSpeakingLogIdException::new);
 
 		// 임시 (아직 로그인 구현 X)
-		Long loginMemberId = 1L;
 
 		Optional<Favorite> favoriteOfLoginMember = favoriteRepository.findByMemberIdAndSpeakingLog(loginMemberId, speakingLog);
 

--- a/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogConditionRequest.java
+++ b/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogConditionRequest.java
@@ -1,7 +1,7 @@
 package com.example.be.core.application.dto.request;
 
 import com.example.be.common.exception.speakinglog.InvalidSpeakingLogDateException;
-import com.example.be.core.domain.SpeakingLogType;
+import com.example.be.core.domain.speakinglog.SpeakingLogType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.ToString;

--- a/be/src/main/java/com/example/be/core/application/dto/response/CommentResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/CommentResponse.java
@@ -1,5 +1,6 @@
 package com.example.be.core.application.dto.response;
 
+import com.example.be.core.domain.speakinglog.Comment;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
@@ -28,10 +29,19 @@ public class CommentResponse {
 	@NotBlank
 	private final String content;
 
-	public CommentResponse(Long commentId, Long memberId, String nickname, String content) {
+	private CommentResponse(Long commentId, Long memberId, String nickname, String content) {
 		this.commentId = commentId;
 		this.memberId = memberId;
 		this.nickname = nickname;
 		this.content = content;
+	}
+
+	public static CommentResponse from(Comment comment) {
+		return new CommentResponse(
+			comment.getId(),
+			comment.getMember().getId(),
+			comment.getMember().getNickname(),
+			comment.getContent()
+		);
 	}
 }

--- a/be/src/main/java/com/example/be/core/application/dto/response/SpeakingLogsResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/SpeakingLogsResponse.java
@@ -1,6 +1,6 @@
 package com.example.be.core.application.dto.response;
 
-import com.example.be.core.domain.SpeakingLogType;
+import com.example.be.core.domain.speakinglog.SpeakingLogType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 

--- a/be/src/main/java/com/example/be/core/domain/member/Member.java
+++ b/be/src/main/java/com/example/be/core/domain/member/Member.java
@@ -1,0 +1,40 @@
+package com.example.be.core.domain.member;
+
+import com.example.be.core.domain.speakinglog.Comment;
+import com.example.be.core.domain.speakinglog.Favorite;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.validation.constraints.Max;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "member_id")
+	private Long id;
+
+	private String nickname;
+
+//	@OneToMany(mappedBy = "speakingLog")
+//	private List<Favorite> favorites = new ArrayList<>();
+//
+//	@OneToMany(mappedBy = "speakingLog")
+//	private List<Comment> comments = new ArrayList<>();
+
+
+	public Member(String nickname) {
+		this.nickname = nickname;
+	}
+}

--- a/be/src/main/java/com/example/be/core/domain/member/Member.java
+++ b/be/src/main/java/com/example/be/core/domain/member/Member.java
@@ -21,13 +21,6 @@ public class Member {
 
 	private String nickname;
 
-//	@OneToMany(mappedBy = "speakingLog")
-//	private List<Favorite> favorites = new ArrayList<>();
-//
-//	@OneToMany(mappedBy = "speakingLog")
-//	private List<Comment> comments = new ArrayList<>();
-
-
 	public Member(String nickname) {
 		this.nickname = nickname;
 	}

--- a/be/src/main/java/com/example/be/core/domain/member/Member.java
+++ b/be/src/main/java/com/example/be/core/domain/member/Member.java
@@ -1,16 +1,10 @@
 package com.example.be.core.domain.member;
 
-import com.example.be.core.domain.speakinglog.Comment;
-import com.example.be.core.domain.speakinglog.Favorite;
-import java.util.ArrayList;
-import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
-import javax.validation.constraints.Max;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/be/src/main/java/com/example/be/core/domain/speakinglog/Comment.java
+++ b/be/src/main/java/com/example/be/core/domain/speakinglog/Comment.java
@@ -1,0 +1,43 @@
+package com.example.be.core.domain.speakinglog;
+
+import com.example.be.core.domain.member.Member;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "comment_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "speaking_log_id")
+	private SpeakingLog speakingLog;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@Lob
+	private String content;
+
+	public Comment(SpeakingLog speakingLog, Member member, String content) {
+		this.speakingLog = speakingLog;
+		this.member = member;
+		this.content = content;
+	}
+}

--- a/be/src/main/java/com/example/be/core/domain/speakinglog/Comment.java
+++ b/be/src/main/java/com/example/be/core/domain/speakinglog/Comment.java
@@ -21,7 +21,7 @@ import org.hibernate.annotations.Where;
 @Entity
 @Where(clause = "deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE speaking_log SET deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE speaking_log SET deleted = true WHERE comment_id = ?")
 public class Comment extends BaseEntity {
 
 	@Id

--- a/be/src/main/java/com/example/be/core/domain/speakinglog/Comment.java
+++ b/be/src/main/java/com/example/be/core/domain/speakinglog/Comment.java
@@ -1,5 +1,6 @@
 package com.example.be.core.domain.speakinglog;
 
+import com.example.be.core.domain.BaseEntity;
 import com.example.be.core.domain.member.Member;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -13,11 +14,15 @@ import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Getter
 @Entity
+@Where(clause = "deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Comment {
+@SQLDelete(sql = "UPDATE speaking_log SET deleted = true WHERE id = ?")
+public class Comment extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/be/src/main/java/com/example/be/core/domain/speakinglog/Favorite.java
+++ b/be/src/main/java/com/example/be/core/domain/speakinglog/Favorite.java
@@ -1,5 +1,6 @@
 package com.example.be.core.domain.speakinglog;
 
+import com.example.be.core.domain.BaseEntity;
 import com.example.be.core.domain.member.Member;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -12,11 +13,15 @@ import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Getter
 @Entity
+@Where(clause = "deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Favorite {
+@SQLDelete(sql = "UPDATE speaking_log SET deleted = true WHERE id = ?")
+public class Favorite extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/be/src/main/java/com/example/be/core/domain/speakinglog/Favorite.java
+++ b/be/src/main/java/com/example/be/core/domain/speakinglog/Favorite.java
@@ -1,6 +1,5 @@
 package com.example.be.core.domain.speakinglog;
 
-import com.example.be.core.domain.BaseEntity;
 import com.example.be.core.domain.member.Member;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -13,15 +12,11 @@ import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 @Getter
 @Entity
-@Where(clause = "deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE speaking_log SET deleted = true WHERE id = ?")
-public class Favorite extends BaseEntity {
+public class Favorite {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/be/src/main/java/com/example/be/core/domain/speakinglog/Favorite.java
+++ b/be/src/main/java/com/example/be/core/domain/speakinglog/Favorite.java
@@ -1,0 +1,38 @@
+package com.example.be.core.domain.speakinglog;
+
+import com.example.be.core.domain.member.Member;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Favorite {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "favorite_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "speaking_log_id")
+	private SpeakingLog speakingLog;
+
+	public Favorite(Member member, SpeakingLog speakingLog) {
+		this.member = member;
+		this.speakingLog = speakingLog;
+	}
+}

--- a/be/src/main/java/com/example/be/core/domain/speakinglog/SpeakingLog.java
+++ b/be/src/main/java/com/example/be/core/domain/speakinglog/SpeakingLog.java
@@ -2,8 +2,6 @@ package com.example.be.core.domain.speakinglog;
 
 import com.example.be.core.domain.BaseEntity;
 import com.example.be.core.domain.member.Member;
-import java.util.ArrayList;
-import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -13,7 +11,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/be/src/main/java/com/example/be/core/domain/speakinglog/SpeakingLog.java
+++ b/be/src/main/java/com/example/be/core/domain/speakinglog/SpeakingLog.java
@@ -1,0 +1,53 @@
+package com.example.be.core.domain.speakinglog;
+
+import com.example.be.core.domain.BaseEntity;
+import com.example.be.core.domain.member.Member;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@Getter
+@Entity
+@Where(clause = "deleted = false")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE speaking_log SET deleted = true WHERE id = ?")
+public class SpeakingLog extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "speaking_log_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	private String title;
+
+	@Lob
+	private String voiceRecord;
+
+	@Lob
+	private String voiceText;
+
+	public SpeakingLog(Member member, String title, String voiceRecord, String voiceText) {
+		this.member = member;
+		this.title = title;
+		this.voiceRecord = voiceRecord;
+		this.voiceText = voiceText;
+	}
+}

--- a/be/src/main/java/com/example/be/core/domain/speakinglog/SpeakingLog.java
+++ b/be/src/main/java/com/example/be/core/domain/speakinglog/SpeakingLog.java
@@ -21,7 +21,7 @@ import org.hibernate.annotations.Where;
 @Entity
 @Where(clause = "deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE speaking_log SET deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE speaking_log SET deleted = true WHERE speaking_log_id = ?")
 public class SpeakingLog extends BaseEntity {
 
 	@Id

--- a/be/src/main/java/com/example/be/core/domain/speakinglog/SpeakingLogType.java
+++ b/be/src/main/java/com/example/be/core/domain/speakinglog/SpeakingLogType.java
@@ -1,4 +1,4 @@
-package com.example.be.core.domain;
+package com.example.be.core.domain.speakinglog;
 
 import com.example.be.common.exception.speakinglog.InvalidSpeakingLogTypeException;
 import java.util.Arrays;

--- a/be/src/main/java/com/example/be/core/repository/member/MemberRespository.java
+++ b/be/src/main/java/com/example/be/core/repository/member/MemberRespository.java
@@ -1,0 +1,10 @@
+package com.example.be.core.repository.member;
+
+import com.example.be.core.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRespository extends JpaRepository<Member, Long> {
+
+}

--- a/be/src/main/java/com/example/be/core/repository/speakinglog/CommentRepository.java
+++ b/be/src/main/java/com/example/be/core/repository/speakinglog/CommentRepository.java
@@ -1,0 +1,12 @@
+package com.example.be.core.repository.speakinglog;
+
+import com.example.be.core.domain.speakinglog.Comment;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+	List<Comment> findAllBySpeakingLogId(Long speakingLogId);
+}

--- a/be/src/main/java/com/example/be/core/repository/speakinglog/FavoriteRepository.java
+++ b/be/src/main/java/com/example/be/core/repository/speakinglog/FavoriteRepository.java
@@ -1,6 +1,5 @@
 package com.example.be.core.repository.speakinglog;
 
-import com.example.be.core.domain.member.Member;
 import com.example.be.core.domain.speakinglog.Favorite;
 import com.example.be.core.domain.speakinglog.SpeakingLog;
 import java.util.Optional;

--- a/be/src/main/java/com/example/be/core/repository/speakinglog/FavoriteRepository.java
+++ b/be/src/main/java/com/example/be/core/repository/speakinglog/FavoriteRepository.java
@@ -1,0 +1,16 @@
+package com.example.be.core.repository.speakinglog;
+
+import com.example.be.core.domain.member.Member;
+import com.example.be.core.domain.speakinglog.Favorite;
+import com.example.be.core.domain.speakinglog.SpeakingLog;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+
+	Integer countBySpeakingLogId(Long speakingLogId);
+
+	Optional<Favorite> findByMemberIdAndSpeakingLog(Long memberId, SpeakingLog speakingLog);
+}

--- a/be/src/main/java/com/example/be/core/repository/speakinglog/SpeakingLogRepository.java
+++ b/be/src/main/java/com/example/be/core/repository/speakinglog/SpeakingLogRepository.java
@@ -1,0 +1,10 @@
+package com.example.be.core.repository.speakinglog;
+
+import com.example.be.core.domain.speakinglog.SpeakingLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SpeakingLogRepository extends JpaRepository<SpeakingLog, Long> {
+
+}

--- a/be/src/main/java/com/example/be/core/web/SpeakingLogController.java
+++ b/be/src/main/java/com/example/be/core/web/SpeakingLogController.java
@@ -33,6 +33,14 @@ public class SpeakingLogController {
 		this.speakingLogService = speakingLogService;
 	}
 
+	@PostMapping
+	@ApiOperation(value = "스피킹 로그 생성입니다.")
+	public BaseResponse<SpeakingLogDetailResponse> create(
+		@RequestBody final SpeakingLogRequest speakingLogRequest) {
+		SpeakingLogDetailResponse response = speakingLogService.create(speakingLogRequest);
+		return new BaseResponse<>(CREATE_SPEAKING_LOG_SUCCESS, response);
+	}
+
 	@GetMapping
 	@ApiOperation(value = "스피킹 로그 타입에 따른 전체 조회입니다.")
 	public BaseResponse<SpeakingLogsResponse> find(SpeakingLogConditionRequest speakingLogConditionRequest) {
@@ -47,13 +55,6 @@ public class SpeakingLogController {
 		return new BaseResponse<>(FIND_DETAIL_SPEAKING_LOG_SUCCESS, response);
 	}
 
-	@DeleteMapping("/{speakingLogId}")
-	@ApiOperation(value = "스피킹 로그 삭제입니다.")
-	public BaseResponse<Void> delete(@PathVariable final Long speakingLogId) {
-		speakingLogService.delete(speakingLogId);
-		return new BaseResponse<>(DELETE_SPEAKING_LOG_SUCCESS, null);
-	}
-
 	@PutMapping("/{speakingLogId}")
 	@ApiOperation(value = "스피킹 로그 수정입니다.")
 	public BaseResponse<SpeakingLogDetailResponse> modify(
@@ -63,11 +64,10 @@ public class SpeakingLogController {
 		return new BaseResponse<>(MODIFY_SPEAKING_LOG_SUCCESS, response);
 	}
 
-	@PostMapping
-	@ApiOperation(value = "스피킹 로그 생성입니다.")
-	public BaseResponse<SpeakingLogDetailResponse> create(
-		@RequestBody final SpeakingLogRequest speakingLogRequest) {
-		SpeakingLogDetailResponse response = speakingLogService.create(speakingLogRequest);
-		return new BaseResponse<>(CREATE_SPEAKING_LOG_SUCCESS, response);
+	@DeleteMapping("/{speakingLogId}")
+	@ApiOperation(value = "스피킹 로그 삭제입니다.")
+	public BaseResponse<Void> delete(@PathVariable final Long speakingLogId) {
+		speakingLogService.delete(speakingLogId);
+		return new BaseResponse<>(DELETE_SPEAKING_LOG_SUCCESS, null);
 	}
 }

--- a/be/src/main/java/com/example/be/core/web/SpeakingLogController.java
+++ b/be/src/main/java/com/example/be/core/web/SpeakingLogController.java
@@ -51,7 +51,7 @@ public class SpeakingLogController {
 	@GetMapping("/{speakingLogId}")
 	@ApiOperation(value = "스피킹 로그 상세 조회입니다.")
 	public BaseResponse<SpeakingLogDetailResponse> findById(@PathVariable final Long speakingLogId) {
-		SpeakingLogDetailResponse response = speakingLogService.findById(speakingLogId);
+		SpeakingLogDetailResponse response = speakingLogService.findById(speakingLogId, 1L);
 		return new BaseResponse<>(FIND_DETAIL_SPEAKING_LOG_SUCCESS, response);
 	}
 

--- a/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogDetailFindTest.java
+++ b/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogDetailFindTest.java
@@ -1,0 +1,76 @@
+package com.example.be.core.application.speakinglog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.be.core.application.SpeakingLogService;
+import com.example.be.core.application.dto.response.SpeakingLogDetailResponse;
+import com.example.be.core.domain.member.Member;
+import com.example.be.core.domain.speakinglog.SpeakingLog;
+import com.example.be.core.repository.member.MemberRespository;
+import com.example.be.core.repository.speakinglog.SpeakingLogRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@DisplayName("서비스 테스트 : SpeakingLog 상세 조회")
+public class SpeakingLogDetailFindTest {
+
+	@Autowired
+	private SpeakingLogService speakingLogService;
+
+	@Autowired
+	private SpeakingLogRepository speakingLogRepository;
+
+	@Autowired
+	private MemberRespository memberRespository;
+
+	@BeforeEach
+	void init() {
+		Member loginMember = new Member("nathan");
+		memberRespository.save(loginMember);
+		SpeakingLog speakingLog = new SpeakingLog(
+			loginMember,
+			"첫 번째 스피킹 로그",
+			"dummy-voice-record-data",
+			"dummy-voice-text-data"
+		);
+		speakingLogRepository.save(speakingLog);
+	}
+
+	@Nested
+	@DisplayName("스피킹 로그를 상세 조회할 때")
+	class DetailFindTest {
+
+		@Nested
+		@DisplayName("정상적인 요청이라면")
+		class NormalTest {
+
+			@Test
+			@DisplayName("해당 아이디를 가진 스피킹 로그가 조회된다.")
+			void normal_detail_find() {
+
+				//given
+				Long speakingLogId = 1L;
+				Long memberId = 1L;
+
+				//when
+				SpeakingLogDetailResponse response = speakingLogService.findById(speakingLogId, memberId);
+
+				//then
+				assertThat(response.getMemberId()).isEqualTo(1L);
+				assertThat(response.getIsLiked()).isFalse();
+				assertThat(response.getLikeCount()).isZero();
+				assertThat(response.getTitle()).isEqualTo("첫 번째 스피킹 로그");
+				assertThat(response.getVoiceRecord()).isEqualTo("dummy-voice-record-data");
+				assertThat(response.getVoiceText()).isEqualTo("dummy-voice-text-data");
+			}
+		}
+	}
+}

--- a/be/src/test/java/com/example/be/core/web/speakinglog/InitSpeakingLogControllerTest.java
+++ b/be/src/test/java/com/example/be/core/web/speakinglog/InitSpeakingLogControllerTest.java
@@ -25,7 +25,7 @@ public abstract class InitSpeakingLogControllerTest {
 	protected ObjectMapper objectMapper;
 
 	@BeforeEach
-	public void init(WebApplicationContext wc) {
+	void init(WebApplicationContext wc) {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wc)
 			.addFilter(new CharacterEncodingFilter("UTF-8", true))
 			.build();

--- a/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerDetailFindTest.java
+++ b/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerDetailFindTest.java
@@ -9,24 +9,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.be.common.response.BaseResponse;
-import com.example.be.core.application.SpeakingLogService;
 import com.example.be.core.application.dto.response.SpeakingLogDetailResponse;
-import com.example.be.core.web.SpeakingLogController;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.CharacterEncodingFilter;
 
 public class SpeakingLogControllerDetailFindTest extends InitSpeakingLogControllerTest{
 
@@ -43,13 +32,13 @@ public class SpeakingLogControllerDetailFindTest extends InitSpeakingLogControll
 			void find_detail_speaking_log() throws Exception {
 				//given
 				Long speakingLogId = 1L;
-				Long memberId = 3L;
+				Long memberId = 1L;
 				Integer likeCount = 10;
 				SpeakingLogDetailResponse response = new SpeakingLogDetailResponse(memberId, "스피킹 로그 1",
 					"dummy-record-abcd-1234", "dummy-text-abcd-1234", likeCount, Boolean.TRUE, new ArrayList<>());
 				BaseResponse<SpeakingLogDetailResponse> baseResponse = new BaseResponse<>(FIND_DETAIL_SPEAKING_LOG_SUCCESS, response);
 
-				when(speakingLogService.findById(refEq(speakingLogId)))
+				when(speakingLogService.findById(refEq(speakingLogId), refEq(memberId)))
 					.thenReturn(response);
 
 				//when
@@ -61,7 +50,7 @@ public class SpeakingLogControllerDetailFindTest extends InitSpeakingLogControll
 				resultActions.andExpect(status().isOk())
 					.andExpect(content().string(objectMapper.writeValueAsString(baseResponse)));
 
-				verify(speakingLogService).findById(refEq(speakingLogId));
+				verify(speakingLogService).findById(refEq(speakingLogId), refEq(memberId));
 			}
 		}
 	}

--- a/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerFindByTypeTest.java
+++ b/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerFindByTypeTest.java
@@ -11,25 +11,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.be.common.response.BaseResponse;
-import com.example.be.core.application.SpeakingLogService;
 import com.example.be.core.application.dto.request.SpeakingLogConditionRequest;
 import com.example.be.core.application.dto.response.SpeakingLogsResponse;
-import com.example.be.core.domain.SpeakingLogType;
-import com.example.be.core.web.SpeakingLogController;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
+import com.example.be.core.domain.speakinglog.SpeakingLogType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.CharacterEncodingFilter;
 
 class SpeakingLogControllerFindByTypeTest extends InitSpeakingLogControllerTest{
 

--- a/be/src/test/resources/application.yml
+++ b/be/src/test/resources/application.yml
@@ -1,0 +1,20 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+
+  datasource:
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:mysql:8://whatever-note?&characterEncoding=UTF-8&serverTimeZone=Asia/Seoul
+    username: admin
+    password: haru-speak-1234
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    dev.whatevernote:
+      be: debug


### PR DESCRIPTION
### ❗️ 이슈 번호

Related to #32 

<br><br>

### 📝 구현 내용

- SpeakingLog 상세 조회 관련 서비스 로직 작성
- 관련 도메인 작성
    - SpeakingLog, Favorite(좋아요), Comment, Member
- 관련 Repository 생성 및 Spring Data JPA 상속
    - SpeakingLogRepository, FavoriteRepository, CommentRepository 

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- SpeakingLogController와 SpeakingLogService 내부 메서드들의 순서를 CRUD 순으로 변경하였습니다!
- Member의 경우 우기가 작성하신 도메인 클래스가 이미 존재하기 때문에 현재 서비스 로직에 필요한 부분에 대해서만 작성을 해 둔 상태입니다.
- 아직 관련 테스트를 작성하지 않았습니다. 
    - 이유는 서비스 로직 작성 업무를 분배하기 위함입니다.(도메인과 레포지토리를 만들어두었으므로 분배 용이) 