### PR TITLE
SpeakingLog 전체 조회 기능 구현

### DIFF
--- a/be/src/main/java/com/example/be/core/application/SpeakingLogService.java
+++ b/be/src/main/java/com/example/be/core/application/SpeakingLogService.java
@@ -67,7 +67,7 @@ public class SpeakingLogService {
 				speakingLog.getTitle(),
 				speakingLog.getVoiceRecord(),
 				getFavoriteCount(speakingLog.getId()),
-				getCommentCount(speakingLog),
+				getCommentCount(speakingLog.getId()),
 				favoriteRepository.findByMemberIdAndSpeakingLog(loginMemberId, speakingLog).isPresent(),
 				speakingLog.getMember().getProfileImage(),
 				speakingLog.getId()
@@ -78,6 +78,7 @@ public class SpeakingLogService {
 			speakingLogResponses
 		);
 	}
+
 
 	public SpeakingLogDetailResponse findById(Long speakingLogId, Long loginMemberId) {
 		log.debug("[스피킹 로그 상세 조회] SpeakingLogId = {}", speakingLogId);
@@ -104,6 +105,10 @@ public class SpeakingLogService {
 		return favoriteRepository.countBySpeakingLogId(speakingLogId);
 	}
 
+	private Integer getCommentCount(Long speakingLogId) {
+		return commentRepository.countBySpeakingLogId(speakingLogId);
+	}
+
 	private List<CommentResponse> getCommentResponses(Long speakingLogId) {
 		return commentRepository.findAllBySpeakingLogId(speakingLogId)
 			.stream()
@@ -111,9 +116,6 @@ public class SpeakingLogService {
 			.collect(Collectors.toList());
 	}
 
-	private int getCommentCount(SpeakingLog speakingLog) {
-		return getCommentResponses(speakingLog.getId()).size();
-	}
 
 	@Transactional
 	public SpeakingLogDetailResponse modify(Long speakingLogId, SpeakingLogModifyRequest speakingLogModifyRequest) {

--- a/be/src/main/java/com/example/be/core/application/SpeakingLogService.java
+++ b/be/src/main/java/com/example/be/core/application/SpeakingLogService.java
@@ -16,6 +16,8 @@ import com.example.be.core.domain.speakinglog.SpeakingLogType;
 import com.example.be.core.repository.speakinglog.CommentRepository;
 import com.example.be.core.repository.speakinglog.FavoriteRepository;
 import com.example.be.core.repository.speakinglog.SpeakingLogRepository;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -48,7 +50,13 @@ public class SpeakingLogService {
 	public SpeakingLogsResponse find(SpeakingLogConditionRequest speakingLogConditionRequest) {
 		log.debug("[스피킹 로그 전체 조회] SpeakingLogConditionRequest = {}",speakingLogConditionRequest.toString());
 
-		List<SpeakingLog> speakingLogs = speakingLogRepository.findAll();
+		LocalDateTime startDateTime = LocalDateTime.of(speakingLogConditionRequest.getDate().minusDays(1),
+			LocalTime.of(0,0,0));
+
+		LocalDateTime endDateTime = LocalDateTime.of(speakingLogConditionRequest.getDate(), LocalTime.of(23,59,59));
+
+		List<SpeakingLog> speakingLogs = speakingLogRepository.findAllByCreatedAtBetween(
+			startDateTime, endDateTime);
 
 		// 임시 (아직 로그인 구현 X)
 		Long loginMemberId = 1L;

--- a/be/src/main/java/com/example/be/core/application/SpeakingLogService.java
+++ b/be/src/main/java/com/example/be/core/application/SpeakingLogService.java
@@ -67,7 +67,7 @@ public class SpeakingLogService {
 				speakingLog.getTitle(),
 				speakingLog.getVoiceRecord(),
 				getFavoriteCount(speakingLog.getId()),
-				getCommentResponses(speakingLog.getId()).size(),
+				getCommentCount(speakingLog),
 				favoriteRepository.findByMemberIdAndSpeakingLog(loginMemberId, speakingLog).isPresent(),
 				speakingLog.getMember().getProfileImage(),
 				speakingLog.getId()
@@ -109,6 +109,10 @@ public class SpeakingLogService {
 			.stream()
 			.map(CommentResponse::from)
 			.collect(Collectors.toList());
+	}
+
+	private int getCommentCount(SpeakingLog speakingLog) {
+		return getCommentResponses(speakingLog.getId()).size();
 	}
 
 	@Transactional

--- a/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogConditionRequest.java
+++ b/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogConditionRequest.java
@@ -9,8 +9,8 @@ import lombok.ToString;
 import java.time.LocalDate;
 import java.util.regex.Pattern;
 
-@ToString
 @Getter
+@ToString
 public class SpeakingLogConditionRequest {
 
 	/**

--- a/be/src/main/java/com/example/be/core/domain/member/Member.java
+++ b/be/src/main/java/com/example/be/core/domain/member/Member.java
@@ -5,6 +5,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Lob;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,9 +27,13 @@ public class Member {
 
 	private String password;
 
-	public Member(String nickname, String email, String password) {
+	@Lob
+	private String profileImage;
+
+	public Member(String nickname, String email, String password, String profileImage) {
 		this.nickname = nickname;
 		this.email = email;
 		this.password = password;
+		this.profileImage = profileImage;
 	}
 }

--- a/be/src/main/java/com/example/be/core/repository/member/MemberRepository.java
+++ b/be/src/main/java/com/example/be/core/repository/member/MemberRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MemberRespository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long> {
 
 }

--- a/be/src/main/java/com/example/be/core/repository/speakinglog/CommentRepository.java
+++ b/be/src/main/java/com/example/be/core/repository/speakinglog/CommentRepository.java
@@ -8,5 +8,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+	Integer countBySpeakingLogId(Long speakingLogId);
+
 	List<Comment> findAllBySpeakingLogId(Long speakingLogId);
 }

--- a/be/src/main/java/com/example/be/core/repository/speakinglog/SpeakingLogRepository.java
+++ b/be/src/main/java/com/example/be/core/repository/speakinglog/SpeakingLogRepository.java
@@ -1,10 +1,15 @@
 package com.example.be.core.repository.speakinglog;
 
+import com.example.be.core.application.dto.request.SpeakingLogConditionRequest;
 import com.example.be.core.domain.speakinglog.SpeakingLog;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SpeakingLogRepository extends JpaRepository<SpeakingLog, Long> {
 
+    List<SpeakingLog> findAllByCreatedAtBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);
 }

--- a/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogDetailFindTest.java
+++ b/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogDetailFindTest.java
@@ -8,7 +8,6 @@ import com.example.be.core.domain.member.Member;
 import com.example.be.core.domain.speakinglog.SpeakingLog;
 import com.example.be.core.repository.member.MemberRespository;
 import com.example.be.core.repository.speakinglog.SpeakingLogRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -33,7 +32,7 @@ public class SpeakingLogDetailFindTest {
 
 	@BeforeEach
 	void init() {
-		Member loginMember = new Member("nathan", "nathan1234@google.com", "asdf1234@");
+		Member loginMember = new Member("nathan", "nathan1234@google.com", "asdf1234@", "profileImage");
 		memberRespository.save(loginMember);
 		SpeakingLog speakingLog = new SpeakingLog(
 			loginMember,

--- a/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogDetailFindTest.java
+++ b/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogDetailFindTest.java
@@ -6,7 +6,7 @@ import com.example.be.core.application.SpeakingLogService;
 import com.example.be.core.application.dto.response.SpeakingLogDetailResponse;
 import com.example.be.core.domain.member.Member;
 import com.example.be.core.domain.speakinglog.SpeakingLog;
-import com.example.be.core.repository.member.MemberRespository;
+import com.example.be.core.repository.member.MemberRepository;
 import com.example.be.core.repository.speakinglog.SpeakingLogRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -28,12 +28,12 @@ public class SpeakingLogDetailFindTest {
 	private SpeakingLogRepository speakingLogRepository;
 
 	@Autowired
-	private MemberRespository memberRespository;
+	private MemberRepository memberRepository;
 
 	@BeforeEach
 	void init() {
 		Member loginMember = new Member("nathan", "nathan1234@google.com", "asdf1234@", "profileImage");
-		memberRespository.save(loginMember);
+		memberRepository.save(loginMember);
 		SpeakingLog speakingLog = new SpeakingLog(
 			loginMember,
 			"첫 번째 스피킹 로그",

--- a/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogFindAllTest.java
+++ b/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogFindAllTest.java
@@ -1,8 +1,10 @@
 package com.example.be.core.application.speakinglog;
 
+import static com.example.be.common.exception.ErrorCodeAndMessages.SPEAKING_LOG_DATE_FORMAT_ERROR;
 import static org.assertj.core.api.Assertions.*;
 
 import com.example.be.common.exception.speakinglog.InvalidSpeakingLogDateException;
+import com.example.be.common.response.BaseResponse;
 import com.example.be.core.application.SpeakingLogService;
 import com.example.be.core.application.dto.request.SpeakingLogConditionRequest;
 import com.example.be.core.application.dto.response.SpeakingLogsResponse;
@@ -12,7 +14,6 @@ import com.example.be.core.repository.member.MemberRepository;
 import com.example.be.core.repository.speakinglog.SpeakingLogRepository;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -73,6 +74,27 @@ public class SpeakingLogFindAllTest {
                 SpeakingLogsResponse response = speakingLogService.find(new SpeakingLogConditionRequest("ALL", today));
                 //then
                 assertThat(response.getSpeakingLogResponses().size()).isEqualTo(2);
+            }
+        }
+
+        @Nested
+        @DisplayName("비정상적인 요청이라면")
+        class AbnormalTest {
+
+            @Nested
+            @DisplayName("날짜 형식이 yyyyMMdd 형식이 아닐 때")
+            class WrongDateFormatTest {
+                @Test
+                @DisplayName("스피킹 로그 전체 조회시 Error 가 발생한다.")
+                void find_all_wrong_date_format_speaking_log() throws Exception{
+                    //given
+                    String today = "2023-01-22";
+                    BaseResponse<SpeakingLogsResponse> baseResponse = new BaseResponse<>(SPEAKING_LOG_DATE_FORMAT_ERROR, null);
+                    //when
+                    //then
+                    assertThatThrownBy(() -> speakingLogService.find(new SpeakingLogConditionRequest("ALL", today)))
+                        .isInstanceOf(InvalidSpeakingLogDateException.class);
+                }
             }
         }
     }

--- a/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogFindAllTest.java
+++ b/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogFindAllTest.java
@@ -1,0 +1,79 @@
+package com.example.be.core.application.speakinglog;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.example.be.common.exception.speakinglog.InvalidSpeakingLogDateException;
+import com.example.be.core.application.SpeakingLogService;
+import com.example.be.core.application.dto.request.SpeakingLogConditionRequest;
+import com.example.be.core.application.dto.response.SpeakingLogsResponse;
+import com.example.be.core.domain.member.Member;
+import com.example.be.core.domain.speakinglog.SpeakingLog;
+import com.example.be.core.repository.member.MemberRepository;
+import com.example.be.core.repository.speakinglog.SpeakingLogRepository;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@DisplayName("서비스 테스트 : SpeakingLog 전체 조회")
+public class SpeakingLogFindAllTest {
+
+    @Autowired
+    private SpeakingLogService speakingLogService;
+
+    @Autowired
+    private SpeakingLogRepository speakingLogRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void init() {
+        Member loginMember = new Member("nathan", "nathan1234@google.com", "asdf1234@", "profileImage");
+        memberRepository.save(loginMember);
+        SpeakingLog speakingLog1 = new SpeakingLog(
+            loginMember,
+            "첫 번째 스피킹 로그",
+            "dummy-voice-record-data",
+            "dummy-voice-text-data"
+        );
+        SpeakingLog speakingLog2 = new SpeakingLog(
+            loginMember,
+            "두 번째 스피킹 로그",
+            "dummy-voice-record-data",
+            "dummy-voice-text-data"
+        );
+        speakingLogRepository.save(speakingLog1);
+        speakingLogRepository.save(speakingLog2);
+    }
+
+    @Nested
+    @DisplayName("스피킹 로그를 전체 조회할 때")
+    class FindAllTest {
+
+        @Nested
+        @DisplayName("정상적인 요청이라면")
+        class NormalTest {
+
+            @Test
+            @DisplayName("전체 스피킹 로그가 조회된다.")
+            void normal_find_all() {
+
+                //given
+                String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+                //when
+                SpeakingLogsResponse response = speakingLogService.find(new SpeakingLogConditionRequest("ALL", today));
+                //then
+                assertThat(response.getSpeakingLogResponses().size()).isEqualTo(2);
+            }
+        }
+    }
+}

--- a/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogFindAllTest.java
+++ b/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogFindAllTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -66,6 +67,7 @@ public class SpeakingLogFindAllTest {
 
             @Test
             @DisplayName("전체 스피킹 로그가 조회된다.")
+            @Transactional
             void normal_find_all() {
 
                 //given
@@ -83,16 +85,17 @@ public class SpeakingLogFindAllTest {
 
             @Nested
             @DisplayName("날짜 형식이 yyyyMMdd 형식이 아닐 때")
+            @Transactional
             class WrongDateFormatTest {
                 @Test
                 @DisplayName("스피킹 로그 전체 조회시 Error 가 발생한다.")
                 void find_all_wrong_date_format_speaking_log() throws Exception{
                     //given
-                    String today = "2023-01-22";
+                    String wrong_date_format = "2023-01-22";
                     BaseResponse<SpeakingLogsResponse> baseResponse = new BaseResponse<>(SPEAKING_LOG_DATE_FORMAT_ERROR, null);
                     //when
                     //then
-                    assertThatThrownBy(() -> speakingLogService.find(new SpeakingLogConditionRequest("ALL", today)))
+                    assertThatThrownBy(() -> speakingLogService.find(new SpeakingLogConditionRequest("ALL", wrong_date_format)))
                         .isInstanceOf(InvalidSpeakingLogDateException.class);
                 }
             }

--- a/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogFindAllTest.java
+++ b/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogFindAllTest.java
@@ -23,8 +23,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-@ActiveProfiles("test")
+@Transactional
 @SpringBootTest
+@ActiveProfiles("test")
 @DisplayName("서비스 테스트 : SpeakingLog 전체 조회")
 public class SpeakingLogFindAllTest {
 
@@ -67,7 +68,6 @@ public class SpeakingLogFindAllTest {
 
             @Test
             @DisplayName("전체 스피킹 로그가 조회된다.")
-            @Transactional
             void normal_find_all() {
 
                 //given
@@ -85,7 +85,6 @@ public class SpeakingLogFindAllTest {
 
             @Nested
             @DisplayName("날짜 형식이 yyyyMMdd 형식이 아닐 때")
-            @Transactional
             class WrongDateFormatTest {
                 @Test
                 @DisplayName("스피킹 로그 전체 조회시 Error 가 발생한다.")

--- a/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogFindAllTest.java
+++ b/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogFindAllTest.java
@@ -69,34 +69,12 @@ public class SpeakingLogFindAllTest {
             @Test
             @DisplayName("전체 스피킹 로그가 조회된다.")
             void normal_find_all() {
-
                 //given
                 String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
                 //when
                 SpeakingLogsResponse response = speakingLogService.find(new SpeakingLogConditionRequest("ALL", today));
                 //then
                 assertThat(response.getSpeakingLogResponses().size()).isEqualTo(2);
-            }
-        }
-
-        @Nested
-        @DisplayName("비정상적인 요청이라면")
-        class AbnormalTest {
-
-            @Nested
-            @DisplayName("날짜 형식이 yyyyMMdd 형식이 아닐 때")
-            class WrongDateFormatTest {
-                @Test
-                @DisplayName("스피킹 로그 전체 조회시 Error 가 발생한다.")
-                void find_all_wrong_date_format_speaking_log() throws Exception{
-                    //given
-                    String wrong_date_format = "2023-01-22";
-                    BaseResponse<SpeakingLogsResponse> baseResponse = new BaseResponse<>(SPEAKING_LOG_DATE_FORMAT_ERROR, null);
-                    //when
-                    //then
-                    assertThatThrownBy(() -> speakingLogService.find(new SpeakingLogConditionRequest("ALL", wrong_date_format)))
-                        .isInstanceOf(InvalidSpeakingLogDateException.class);
-                }
             }
         }
     }


### PR DESCRIPTION
### ❗️ 이슈 번호

Closes #34 

<br><br>

### 📝 구현 내용

- createdAt에 대한 SpeakingLog 전체 조회 기능 구현
- createdAt에 대한 SpeakingLog 전체 조회 테스트 코드 작성 
    - 전체 조회 성공시 테스트 코드 작성
    - date 형식이 맞지않아 실패시 테스트 코드 작성
- Member Entity에 profileImage 필드 추가

<img width="1366" alt="image" src="https://user-images.githubusercontent.com/49313910/213911198-216d924c-d418-4dd6-9ba5-40ff92835cb4.png">

