### PR TITLE
SpeakingLog 생성 기능 구현 및 관련 테스트 작성(with 테스트 격리 설정 추가)

### DIFF
--- a/be/src/main/java/com/example/be/common/exception/ErrorCodeAndMessages.java
+++ b/be/src/main/java/com/example/be/common/exception/ErrorCodeAndMessages.java
@@ -18,6 +18,7 @@ public enum ErrorCodeAndMessages implements CodeAndMessages {
 	 * 404 Not Found
 	 */
 	SPEAKING_LOG_ID_NOT_FOUND_ERROR("E-NF001", "스피킹 로그 아이디를 찾을 수 없습니다."),
+	LOGIN_MEMBER_NOT_FOUND_ERROR("E-NF002", "로그인 된 멤버를 찾을 수 없습니다."),
 	;
 
 	private final String code;

--- a/be/src/main/java/com/example/be/common/exception/speakinglog/NotFoundMemberIdException.java
+++ b/be/src/main/java/com/example/be/common/exception/speakinglog/NotFoundMemberIdException.java
@@ -1,0 +1,11 @@
+package com.example.be.common.exception.speakinglog;
+
+import com.example.be.common.exception.BaseException;
+import com.example.be.common.exception.ErrorCodeAndMessages;
+
+public class NotFoundMemberIdException extends BaseException {
+
+	public NotFoundMemberIdException() {
+		super(ErrorCodeAndMessages.LOGIN_MEMBER_NOT_FOUND_ERROR);
+	}
+}

--- a/be/src/main/java/com/example/be/core/web/SpeakingLogController.java
+++ b/be/src/main/java/com/example/be/core/web/SpeakingLogController.java
@@ -37,7 +37,7 @@ public class SpeakingLogController {
 	@ApiOperation(value = "스피킹 로그 생성입니다.")
 	public BaseResponse<SpeakingLogDetailResponse> create(
 		@RequestBody final SpeakingLogRequest speakingLogRequest) {
-		SpeakingLogDetailResponse response = speakingLogService.create(speakingLogRequest);
+		SpeakingLogDetailResponse response = speakingLogService.create(speakingLogRequest, 1L);
 		return new BaseResponse<>(CREATE_SPEAKING_LOG_SUCCESS, response);
 	}
 

--- a/be/src/test/java/com/example/be/core/application/InitServiceTest.java
+++ b/be/src/test/java/com/example/be/core/application/InitServiceTest.java
@@ -1,0 +1,21 @@
+package com.example.be.core.application;
+
+import com.example.be.core.tool.DataBaseConfigurator;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public abstract class InitServiceTest {
+
+	@Autowired
+	private DataBaseConfigurator dbConfigurator;
+
+	@BeforeEach
+	void setUpDataBase() {
+		dbConfigurator.clear();
+		dbConfigurator.initDataSource();
+	}
+}

--- a/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogCreateTest.java
+++ b/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogCreateTest.java
@@ -1,0 +1,73 @@
+package com.example.be.core.application.speakinglog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.example.be.common.exception.BaseException;
+import com.example.be.common.exception.speakinglog.NotFoundMemberIdException;
+import com.example.be.core.application.InitServiceTest;
+import com.example.be.core.application.SpeakingLogService;
+import com.example.be.core.application.dto.request.SpeakingLogRequest;
+import com.example.be.core.application.dto.response.SpeakingLogDetailResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("서비스 테스트 : SpeakingLog 생성")
+public class SpeakingLogCreateTest extends InitServiceTest {
+
+	@Autowired
+	private SpeakingLogService speakingLogService;
+
+	@Nested
+	@DisplayName("새로운 스피킹 로그를 생성할 때")
+	class CreateTest {
+
+		@Nested
+		@DisplayName("정상적인 요청이라면")
+		class NormalTest {
+
+			@Test
+			@DisplayName("로그인 한 멤버의 스피킹 로그가 생성된다.")
+			void normal_create() {
+
+				//given
+				Long memberId = 1L;
+				SpeakingLogRequest request = new SpeakingLogRequest("동동의 스피킹 로그",
+					"dummy-voice-record-data", "dummy-voice-text-data");
+
+				//when
+				SpeakingLogDetailResponse response = speakingLogService.create(request, memberId);
+
+				//then
+				assertThat(response.getMemberId()).isEqualTo(1L);
+				assertThat(response.getIsLiked()).isFalse();
+				assertThat(response.getLikeCount()).isZero();
+				assertThat(response.getTitle()).isEqualTo("동동의 스피킹 로그");
+				assertThat(response.getVoiceRecord()).isEqualTo("dummy-voice-record-data");
+				assertThat(response.getVoiceText()).isEqualTo("dummy-voice-text-data");
+			}
+		}
+
+		@Nested
+		@DisplayName("비정상적인 요청이라면")
+		class AbnormalTest {
+
+			@Test
+			@DisplayName("로그인 멤버 ID가 잘못된 경우 예외(NotFoundMemberIdException)를 던진다.")
+			void abnormal_login_member_id_is_wrong() {
+
+				//given
+				Long memberId = (long) Integer.MAX_VALUE;
+				SpeakingLogRequest request = new SpeakingLogRequest("동동의 스피킹 로그",
+					"dummy-voice-record-data", "dummy-voice-text-data");
+
+				//when & then
+				assertThatThrownBy(() -> speakingLogService.create(request, memberId))
+					.isInstanceOf(BaseException.class)
+					.isExactlyInstanceOf(NotFoundMemberIdException.class);
+			}
+		}
+	}
+}

--- a/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogDetailFindTest.java
+++ b/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogDetailFindTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.example.be.common.exception.BaseException;
-import com.example.be.common.exception.ErrorCodeAndMessages;
 import com.example.be.common.exception.speakinglog.NotFoundSpeakingLogIdException;
 import com.example.be.core.application.InitServiceTest;
 import com.example.be.core.application.SpeakingLogService;

--- a/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogDetailFindTest.java
+++ b/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogDetailFindTest.java
@@ -2,47 +2,18 @@ package com.example.be.core.application.speakinglog;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.example.be.core.application.InitServiceTest;
 import com.example.be.core.application.SpeakingLogService;
 import com.example.be.core.application.dto.response.SpeakingLogDetailResponse;
-import com.example.be.core.domain.member.Member;
-import com.example.be.core.domain.speakinglog.SpeakingLog;
-import com.example.be.core.repository.member.MemberRespository;
-import com.example.be.core.repository.speakinglog.SpeakingLogRepository;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("test")
-@SpringBootTest
 @DisplayName("서비스 테스트 : SpeakingLog 상세 조회")
-public class SpeakingLogDetailFindTest {
-
+public class SpeakingLogDetailFindTest extends InitServiceTest {
 	@Autowired
 	private SpeakingLogService speakingLogService;
-
-	@Autowired
-	private SpeakingLogRepository speakingLogRepository;
-
-	@Autowired
-	private MemberRespository memberRespository;
-
-	@BeforeEach
-	void init() {
-		Member loginMember = new Member("nathan", "nathan1234@google.com", "asdf1234@");
-		memberRespository.save(loginMember);
-		SpeakingLog speakingLog = new SpeakingLog(
-			loginMember,
-			"첫 번째 스피킹 로그",
-			"dummy-voice-record-data",
-			"dummy-voice-text-data"
-		);
-		speakingLogRepository.save(speakingLog);
-	}
 
 	@Nested
 	@DisplayName("스피킹 로그를 상세 조회할 때")
@@ -67,9 +38,9 @@ public class SpeakingLogDetailFindTest {
 				assertThat(response.getMemberId()).isEqualTo(1L);
 				assertThat(response.getIsLiked()).isFalse();
 				assertThat(response.getLikeCount()).isZero();
-				assertThat(response.getTitle()).isEqualTo("첫 번째 스피킹 로그");
-				assertThat(response.getVoiceRecord()).isEqualTo("dummy-voice-record-data");
-				assertThat(response.getVoiceText()).isEqualTo("dummy-voice-text-data");
+				assertThat(response.getTitle()).isEqualTo("speaking-log-title11");
+				assertThat(response.getVoiceRecord()).isEqualTo("dummy-voice-record11");
+				assertThat(response.getVoiceText()).isEqualTo("dummy-voice-text11");
 			}
 		}
 	}

--- a/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogDetailFindTest.java
+++ b/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogDetailFindTest.java
@@ -1,7 +1,12 @@
 package com.example.be.core.application.speakinglog;
 
+import static com.example.be.common.exception.ErrorCodeAndMessages.SPEAKING_LOG_ID_NOT_FOUND_ERROR;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.example.be.common.exception.BaseException;
+import com.example.be.common.exception.ErrorCodeAndMessages;
+import com.example.be.common.exception.speakinglog.NotFoundSpeakingLogIdException;
 import com.example.be.core.application.InitServiceTest;
 import com.example.be.core.application.SpeakingLogService;
 import com.example.be.core.application.dto.response.SpeakingLogDetailResponse;
@@ -41,6 +46,32 @@ public class SpeakingLogDetailFindTest extends InitServiceTest {
 				assertThat(response.getTitle()).isEqualTo("speaking-log-title11");
 				assertThat(response.getVoiceRecord()).isEqualTo("dummy-voice-record11");
 				assertThat(response.getVoiceText()).isEqualTo("dummy-voice-text11");
+			}
+		}
+
+		@Nested
+		@DisplayName("비정상적인 요청이라면")
+		class AbnormalTest {
+
+			@Nested
+			@DisplayName("스피킹 로그 아이디가 없는 아이디 일 때")
+			class WrongSpeakingLogId {
+
+				@Test
+				@DisplayName("예외(NotFoundSpeakingLogIdException)를 던진다.")
+				void normal_detail_find() {
+
+					//given
+					Long speakingLogId = (long) Integer.MAX_VALUE;
+					Long memberId = 1L;
+
+					//when & then
+					assertThatThrownBy(() -> speakingLogService.findById(speakingLogId, memberId))
+						.isInstanceOf(BaseException.class)
+						.isExactlyInstanceOf(NotFoundSpeakingLogIdException.class)
+						.hasMessage(SPEAKING_LOG_ID_NOT_FOUND_ERROR.getMessage());
+				}
+
 			}
 		}
 	}

--- a/be/src/test/java/com/example/be/core/tool/DataBaseConfigurator.java
+++ b/be/src/test/java/com/example/be/core/tool/DataBaseConfigurator.java
@@ -1,0 +1,119 @@
+package com.example.be.core.tool;
+
+import com.example.be.common.exception.speakinglog.NotFoundMemberIdException;
+import com.example.be.core.domain.member.Member;
+import com.example.be.core.domain.speakinglog.SpeakingLog;
+import com.example.be.core.repository.member.MemberRespository;
+import com.example.be.core.repository.speakinglog.SpeakingLogRepository;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.hibernate.Session;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataBaseConfigurator implements InitializingBean {
+
+	private static final String SET_FOREIGN_KEY_CHECKS = "SET FOREIGN_KEY_CHECKS = ";
+	private static final String TRUNCATE_TABLE = "TRUNCATE TABLE ";
+	private static final String TABLE = "TABLE";
+	private static final String TABLE_NAME = "table_name";
+
+	private static final int NUMBER_OF_MEMBER = 5;
+	private static final int NUMBER_OF_SPEAKING_LOG = 3;
+
+	@Autowired
+	private MemberRespository memberRespository;
+
+	@Autowired
+	private SpeakingLogRepository speakingLogRepository;
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	private List<String> tableNames;
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		entityManager.unwrap(Session.class).doWork(this::extractTableNames);
+	}
+
+	private void extractTableNames(Connection connection) throws SQLException {
+
+		List<String> tableNames = new ArrayList<>();
+		ResultSet tables = connection.getMetaData()
+			.getTables(connection.getCatalog(), null, null, new String[]{TABLE});
+
+		try (tables) {
+			while (tables.next()) {
+				tableNames.add(tables.getString(TABLE_NAME));
+			}
+
+			this.tableNames = tableNames;
+		}
+	}
+
+	public void clear() {
+		entityManager.unwrap(Session.class).doWork(this::cleanUpDataBase);
+	}
+
+	private void cleanUpDataBase(Connection connection) throws SQLException {
+		try (Statement statement = connection.createStatement()) {
+			statement.executeUpdate(SET_FOREIGN_KEY_CHECKS + "0");
+			for (String tableName : tableNames) {
+				statement.executeUpdate(TRUNCATE_TABLE + tableName);
+			}
+			statement.executeUpdate(SET_FOREIGN_KEY_CHECKS + "1");
+		}
+	}
+
+	public void initDataSource() {
+		initMember();
+		initSpeakingLog();
+	}
+
+	/**
+	 * Member
+	 * 도메인 객체를 NUMBER_OF_MEMBER 만큼 생성합니다.
+	 */
+	private void initMember() {
+		for (int i = 1; i <= NUMBER_OF_MEMBER; i++) {
+			memberRespository.save(
+				new Member(
+				"member" + i,
+				"member-email" + i + "@google.com",
+				"password1234" + i
+				));
+		}
+	}
+
+	/**
+	 * SpeakingLog
+	 * 도메인 객체를 각 멤버 마다 NUMBER_OF_SPEAKING_LOG 만큼 생성합니다.
+	 */
+	private void initSpeakingLog() {
+		for (int i = 1; i <= NUMBER_OF_MEMBER; i++) {
+			Member member = memberRespository.findById((long) i)
+				.orElseThrow(NotFoundMemberIdException::new);
+
+			for (int j = 1; j <= NUMBER_OF_SPEAKING_LOG; j++) {
+				speakingLogRepository.save(
+					new SpeakingLog(
+						member,
+						"speaking-log-title"+i+j,
+						"dummy-voice-record"+i+j,
+						"dummy-voice-text"+i+j
+					));
+			}
+		}
+
+	}
+}

--- a/be/src/test/java/com/example/be/core/tool/DataBaseConfigurator.java
+++ b/be/src/test/java/com/example/be/core/tool/DataBaseConfigurator.java
@@ -11,7 +11,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import org.hibernate.Session;

--- a/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerCreateTest.java
+++ b/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerCreateTest.java
@@ -31,15 +31,14 @@ public class SpeakingLogControllerCreateTest extends InitSpeakingLogControllerTe
             @DisplayName("스프킹 로그 생성시, 해당 멤버 ID를 가진 스피킹 로그가 생성된다.")
             void create_speaking_log() throws Exception {
                 //given
-                Long speakingLogId = 1L;
-                Long memberId = 3L;
+                Long memberId = 1L;
                 Integer likeCount = 10;
                 SpeakingLogRequest request = new SpeakingLogRequest("스피킹 로그1", "dummy_record_adsf_1234", "dummy_text_asdf_1234");
                 SpeakingLogDetailResponse response = new SpeakingLogDetailResponse( memberId, "스피킹 로그1",
                         "dummy_record_adsf_1234","dummy_text_asdf_1234", likeCount, false,  new ArrayList<>());
                 BaseResponse<SpeakingLogDetailResponse> baseResponse = new BaseResponse<>(CREATE_SPEAKING_LOG_SUCCESS, response);
 
-                when(speakingLogService.create(refEq(request)))
+                when(speakingLogService.create(refEq(request), refEq(memberId)))
                     .thenReturn(response);
 
                 //when
@@ -52,7 +51,7 @@ public class SpeakingLogControllerCreateTest extends InitSpeakingLogControllerTe
                 resultActions.andExpect(status().isOk())
                     .andExpect(content().string(objectMapper.writeValueAsString(baseResponse)));
 
-                verify(speakingLogService).create(refEq(request));
+                verify(speakingLogService).create(refEq(request), refEq(memberId));
             }
         }
     }

--- a/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerDeleteTest.java
+++ b/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerDeleteTest.java
@@ -1,30 +1,19 @@
 package com.example.be.core.web.speakinglog;
 
 
-import com.example.be.common.response.BaseResponse;
-import com.example.be.core.application.SpeakingLogService;
-import com.example.be.core.web.SpeakingLogController;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.CharacterEncodingFilter;
-
 import static com.example.be.common.response.ResponseCodeAndMessages.DELETE_SPEAKING_LOG_SUCCESS;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.be.common.response.BaseResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
 
 public class SpeakingLogControllerDeleteTest extends InitSpeakingLogControllerTest{
 

--- a/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerModifyTest.java
+++ b/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerModifyTest.java
@@ -9,25 +9,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.be.common.response.BaseResponse;
-import com.example.be.core.application.SpeakingLogService;
 import com.example.be.core.application.dto.request.SpeakingLogModifyRequest;
 import com.example.be.core.application.dto.response.SpeakingLogDetailResponse;
-import com.example.be.core.web.SpeakingLogController;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.CharacterEncodingFilter;
 
 public class SpeakingLogControllerModifyTest extends InitSpeakingLogControllerTest{
 


### PR DESCRIPTION
### ❗️ 이슈 번호

Closes #37

<br><br>

### 📝 구현 내용

- SpeakingLog 생성 기능 구현
- SpeakingLog 생성 기능 테스트 작성
- 테스트 격리를 위한 설정 파일 작성

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- 테스트 격리를 위해 테스트 컨테이너를 사용하였습니다.
- 또한 DB 내의 테스트용 데이터 생성을 위해 DataBaseConfigurator라는 설정 관련 클래스를 만들고, Service Test시 사용할 수 있는 InitServiceTest를 작성하였습니다.
- 이를 통해 기존의 `@BeforeEach`로 일일히 데이터를 넣어줄 필요가 없어졌습니다. 
- 대신, DataBaseConfigurator에서 어떤 데이터들을 만드는지는 숙지를 해야 테스트 데이터를 이용할 수 있습니다 

<img width="489" alt="image" src="https://user-images.githubusercontent.com/67811880/213916578-a67c7987-559e-4dd0-b5aa-687b456587f5.png">


<br><br>

### 💡 참고 자료

<img width="549" alt="image" src="https://user-images.githubusercontent.com/67811880/213916596-58464b55-c329-4e21-8eb3-f796a23c5b3c.png">

