### PR TITLE
SpeakingLog 삭제 기능 구현

### DIFF
--- a/be/src/main/java/com/example/be/core/application/SpeakingLogService.java
+++ b/be/src/main/java/com/example/be/core/application/SpeakingLogService.java
@@ -1,7 +1,5 @@
 package com.example.be.core.application;
 
-import static com.example.be.core.domain.speakinglog.SpeakingLogType.*;
-
 import com.example.be.common.exception.speakinglog.NotFoundMemberIdException;
 import com.example.be.common.exception.speakinglog.NotFoundSpeakingLogIdException;
 import com.example.be.core.application.dto.request.SpeakingLogConditionRequest;
@@ -15,14 +13,13 @@ import com.example.be.core.domain.member.Member;
 import com.example.be.core.domain.speakinglog.Favorite;
 import com.example.be.core.domain.speakinglog.SpeakingLog;
 import com.example.be.core.repository.member.MemberRepository;
-import com.example.be.core.domain.speakinglog.SpeakingLogType;
 import com.example.be.core.repository.speakinglog.CommentRepository;
 import com.example.be.core.repository.speakinglog.FavoriteRepository;
 import com.example.be.core.repository.speakinglog.SpeakingLogRepository;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -154,6 +151,8 @@ public class SpeakingLogService {
 
 	@Transactional
 	public void delete(Long speakingLogId) {
-		log.debug("SpeakingLogId = {}", speakingLogId);
+		log.debug("[스피킹 로그 삭제] SpeakingLogId = {}", speakingLogId);
+
+		speakingLogRepository.deleteById(speakingLogId);
 	}
 }

--- a/be/src/main/java/com/example/be/core/repository/speakinglog/SpeakingLogRepository.java
+++ b/be/src/main/java/com/example/be/core/repository/speakinglog/SpeakingLogRepository.java
@@ -1,8 +1,6 @@
 package com.example.be.core.repository.speakinglog;
 
-import com.example.be.core.application.dto.request.SpeakingLogConditionRequest;
 import com.example.be.core.domain.speakinglog.SpeakingLog;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogDeleteTest.java
+++ b/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogDeleteTest.java
@@ -1,0 +1,50 @@
+package com.example.be.core.application.speakinglog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.be.core.application.InitServiceTest;
+import com.example.be.core.application.SpeakingLogService;
+import com.example.be.core.domain.speakinglog.SpeakingLog;
+import com.example.be.core.repository.speakinglog.SpeakingLogRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("서비스 테스트 : SpeakingLog 삭제")
+public class SpeakingLogDeleteTest extends InitServiceTest {
+
+    @Autowired
+    private SpeakingLogService speakingLogService;
+
+    @Autowired
+    private SpeakingLogRepository speakingLogRepository;
+
+    @Nested
+    @DisplayName("스피킹 로그를 삭제할 때")
+    class deleteTest {
+
+        @Nested
+        @DisplayName("정상적인 요청이라면")
+        class NormalTest {
+
+            @Test
+            @DisplayName("삭제 전과 삭제 후의 스피킹 로그 수 차이가 발생한다.")
+            void normal_delete() throws Exception {
+
+                //given
+                Long speakingLogId = 1L;
+                List<SpeakingLog> before = speakingLogRepository.findAll();
+                assertThat(before.size()).isEqualTo(15);
+
+                //when
+                speakingLogService.delete(speakingLogId);
+
+                //then
+                List<SpeakingLog> after = speakingLogRepository.findAll();
+                assertThat(after).size().isEqualTo(14);
+            }
+        }
+    }
+}

--- a/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogFindAllTest.java
+++ b/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogFindAllTest.java
@@ -1,62 +1,25 @@
 package com.example.be.core.application.speakinglog;
 
-import static com.example.be.common.exception.ErrorCodeAndMessages.SPEAKING_LOG_DATE_FORMAT_ERROR;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import com.example.be.common.exception.speakinglog.InvalidSpeakingLogDateException;
-import com.example.be.common.response.BaseResponse;
+import com.example.be.core.application.InitServiceTest;
 import com.example.be.core.application.SpeakingLogService;
 import com.example.be.core.application.dto.request.SpeakingLogConditionRequest;
 import com.example.be.core.application.dto.response.SpeakingLogsResponse;
-import com.example.be.core.domain.member.Member;
-import com.example.be.core.domain.speakinglog.SpeakingLog;
-import com.example.be.core.repository.member.MemberRepository;
-import com.example.be.core.repository.speakinglog.SpeakingLogRepository;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-@SpringBootTest
-@ActiveProfiles("test")
 @DisplayName("서비스 테스트 : SpeakingLog 전체 조회")
-public class SpeakingLogFindAllTest {
+public class SpeakingLogFindAllTest extends InitServiceTest {
 
     @Autowired
     private SpeakingLogService speakingLogService;
-
-    @Autowired
-    private SpeakingLogRepository speakingLogRepository;
-
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @BeforeEach
-    void init() {
-        Member loginMember = new Member("nathan", "nathan1234@google.com", "asdf1234@", "profileImage");
-        memberRepository.save(loginMember);
-        SpeakingLog speakingLog1 = new SpeakingLog(
-            loginMember,
-            "첫 번째 스피킹 로그",
-            "dummy-voice-record-data",
-            "dummy-voice-text-data"
-        );
-        SpeakingLog speakingLog2 = new SpeakingLog(
-            loginMember,
-            "두 번째 스피킹 로그",
-            "dummy-voice-record-data",
-            "dummy-voice-text-data"
-        );
-        speakingLogRepository.save(speakingLog1);
-        speakingLogRepository.save(speakingLog2);
-    }
 
     @Nested
     @DisplayName("스피킹 로그를 전체 조회할 때")
@@ -74,7 +37,7 @@ public class SpeakingLogFindAllTest {
                 //when
                 SpeakingLogsResponse response = speakingLogService.find(new SpeakingLogConditionRequest("ALL", today));
                 //then
-                assertThat(response.getSpeakingLogResponses().size()).isEqualTo(2);
+                assertThat(response.getSpeakingLogResponses().size()).isEqualTo(15);
             }
         }
     }

--- a/be/src/test/java/com/example/be/core/tool/DataBaseConfigurator.java
+++ b/be/src/test/java/com/example/be/core/tool/DataBaseConfigurator.java
@@ -3,7 +3,7 @@ package com.example.be.core.tool;
 import com.example.be.common.exception.speakinglog.NotFoundMemberIdException;
 import com.example.be.core.domain.member.Member;
 import com.example.be.core.domain.speakinglog.SpeakingLog;
-import com.example.be.core.repository.member.MemberRespository;
+import com.example.be.core.repository.member.MemberRepository;
 import com.example.be.core.repository.speakinglog.SpeakingLogRepository;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -30,7 +30,7 @@ public class DataBaseConfigurator implements InitializingBean {
 	private static final int NUMBER_OF_SPEAKING_LOG = 3;
 
 	@Autowired
-	private MemberRespository memberRespository;
+	private MemberRepository memberRepository;
 
 	@Autowired
 	private SpeakingLogRepository speakingLogRepository;
@@ -85,11 +85,12 @@ public class DataBaseConfigurator implements InitializingBean {
 	 */
 	private void initMember() {
 		for (int i = 1; i <= NUMBER_OF_MEMBER; i++) {
-			memberRespository.save(
+			memberRepository.save(
 				new Member(
 				"member" + i,
 				"member-email" + i + "@google.com",
-				"password1234" + i
+				"password1234" + i,
+					"profileImage" + i
 				));
 		}
 	}
@@ -100,7 +101,7 @@ public class DataBaseConfigurator implements InitializingBean {
 	 */
 	private void initSpeakingLog() {
 		for (int i = 1; i <= NUMBER_OF_MEMBER; i++) {
-			Member member = memberRespository.findById((long) i)
+			Member member = memberRepository.findById((long) i)
 				.orElseThrow(NotFoundMemberIdException::new);
 
 			for (int j = 1; j <= NUMBER_OF_SPEAKING_LOG; j++) {


### PR DESCRIPTION
### ❗️ 이슈 번호

Closes #36 

<br><br>

### 📝 구현 내용

- 스피킹 로그 삭제 기능 구현
- 스피킹 로그 삭제 테스트 코드 작성

<img width="518" alt="image" src="https://user-images.githubusercontent.com/49313910/213929349-4706bb36-b740-4f9a-b092-ae12a3656d35.png">

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- soft delete로 하기로 했기 때문에 삭제 된 스피킹 로그의 deleted 는 true로 업데이트 됩니다. 이 부분도 테스트 코드로 확인하기 위해 작성하려고 했는데 실제 DB에는 update 쿼리가 잘 보내지지만 영속성 컨텍스트가 비워지지 않고 새로운 스피킹 로그 정보를 불러오지 않아서 그런지 지워졌음에도 계속 false 값으로 확인이 되더군요... 이 부분을 해결하기 위해서 어떻게 해야할지 도움을 구합니다!

<img width="510" alt="image" src="https://user-images.githubusercontent.com/49313910/213930683-cd45b34f-24ae-4c9a-b043-88c162f272e2.png">

<img width="341" alt="image" src="https://user-images.githubusercontent.com/49313910/213929732-f96b01ed-3d6b-4e78-ac4a-2c424db8cfad.png">
  
