### PR TITLE
Member 회원가입 기능 구현 완료

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     // Test
+    testCompileOnly 'org.projectlombok:lombok:1.18.12'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.12'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     // TestContainers

--- a/be/src/main/java/com/example/be/common/config/SwaggerConfig.java
+++ b/be/src/main/java/com/example/be/common/config/SwaggerConfig.java
@@ -25,8 +25,7 @@ public class SwaggerConfig {
 			.groupName("haru-speak")
 			.apiInfo(apiInfo())
 			.select()
-			.apis(RequestHandlerSelectors
-				.basePackage("com.example.be"))
+			.apis(RequestHandlerSelectors.basePackage("com.example.be"))
 			.paths(PathSelectors.any())
 			.build()
 			.securityContexts(Collections.singletonList(securityContext()))

--- a/be/src/main/java/com/example/be/common/config/WebConfig.java
+++ b/be/src/main/java/com/example/be/common/config/WebConfig.java
@@ -10,7 +10,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
-
 	private final OAuthInterceptor oAuthInterceptor;
 	private final LoginArgumentResolver loginArgumentResolver;
 

--- a/be/src/main/java/com/example/be/common/exception/ErrorCodeAndMessages.java
+++ b/be/src/main/java/com/example/be/common/exception/ErrorCodeAndMessages.java
@@ -12,11 +12,18 @@ public enum ErrorCodeAndMessages implements CodeAndMessages {
 	 * 400 Bad Request
 	 */
 	BAD_REQUEST_ERROR("E-BR000", "잘못된 요청입니다."),
-	SPEAKING_LOG_TYPE_ERROR("E-BR001", "올바르지 않은 타입 형식입니다. ALL, MY, MATE 중 하나여야 합니다."),
+	SPEAKING_LOG_TYPE_ERROR("E-BR001", "올바르지 않은 SpeakingLogType 형식입니다. ALL, MY, MATE 중 하나여야 합니다."),
   	SPEAKING_LOG_DATE_FORMAT_ERROR("E-BR002", "올바르지 않은 날짜 형식입니다. YYYYMMDD 형식이어야 합니다."),
-	STUDY_TYPE_ERROR("E-BR003", "올바르지 않은 타입 형식입니다. ALL, MY, MATE 중 하나여야 합니다."),
+	STUDY_TYPE_ERROR("E-BR003", "올바르지 않은 StudyType 형식입니다. ALL, MY, MATE 중 하나여야 합니다."),
 	INVALID_JWT_TOKEN_ERROR("E-BR004", "유효하지 않은 JWT Token 입니다."),
 	NOT_LOGGED_IN_ERROR("E-BR005", "로그인하지 않은 유저입니다."),
+	MEMBER_TYPE_ERROR("E-BR006", "올바르지 않은 MemberType 형식입니다. "
+			+ "elementary_school, middle_school, high_school, university, office_worker, job_seeker, free 중 하나여야 합니다."),
+	SPEAKING_GRADE_LANGUAGE_ERROR("E-BR007", "올바르지 않은 SpeakingGradeLanguage 형식입니다."
+		+ "eng, kor 중 하나여야 합니다."),
+	SPEAKING_GRADE_LEVEL_ERROR("E-BR008", "올바르지 않은 SpeakingGradeLevel 형식입니다."
+		+ "1, 2, 3, 4, 5 중 하나여야 합니다."),
+
 
 	/**
 	 * 404 Not Found
@@ -26,6 +33,8 @@ public enum ErrorCodeAndMessages implements CodeAndMessages {
 	LOGIN_MEMBER_NOT_FOUND_ERROR("E-NF002", "로그인 된 멤버를 찾을 수 없습니다."),
 	STUDY_ID_NOT_FOUND_ERROR("E-NF003", "스터디 아이디를 찾을 수 없습니다."),
 	ASSIGNMENT_ID_NOT_FOUND_ERROR("E-NF004", "과제 아이디를 찾을 수 없습니다."),
+	GOAL_ID_NOT_FOUND_ERROR("E-NF005", "목표 아이디를 찾을 수 없습니다."),
+	SUBJECT_ID_NOT_FOUND_ERROR("E-NF006", "주제 아이디를 찾을 수 없습니다."),
 	;
 
 	private final String code;

--- a/be/src/main/java/com/example/be/common/exception/ErrorCodeAndMessages.java
+++ b/be/src/main/java/com/example/be/common/exception/ErrorCodeAndMessages.java
@@ -23,6 +23,8 @@ public enum ErrorCodeAndMessages implements CodeAndMessages {
 		+ "eng, kor 중 하나여야 합니다."),
 	SPEAKING_GRADE_LEVEL_ERROR("E-BR008", "올바르지 않은 SpeakingGradeLevel 형식입니다."
 		+ "1, 2, 3, 4, 5 중 하나여야 합니다."),
+	SPEAKING_TEST_TYPE_ERROR("E-BR009", "올바르지 않은 SpeakingTestType 형식입니다."
+		+ "OPIC, TOEFL, TOEIC_SPEAKING 중 하나여야 합니다."),
 
 
 	/**

--- a/be/src/main/java/com/example/be/common/exception/GlobalExceptionHandler.java
+++ b/be/src/main/java/com/example/be/common/exception/GlobalExceptionHandler.java
@@ -3,7 +3,6 @@ package com.example.be.common.exception;
 import static com.example.be.common.exception.ErrorCodeAndMessages.BAD_REQUEST_ERROR;
 
 import com.example.be.common.response.BaseResponse;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
@@ -23,9 +22,12 @@ public class GlobalExceptionHandler {
 	 */
 	@ExceptionHandler(HttpMessageNotReadableException.class)
 	private BaseResponse<Void> handleBadRequest(HttpMessageNotReadableException e) {
-		log.error("HttpMessageNotReadableException: {}", e.getMessage());
-		return BaseResponse.error(BAD_REQUEST_ERROR.getCode(),
-			":".split(Objects.requireNonNull(e.getMessage()))[0]);
+		Throwable mostSpecificCause = e.getMostSpecificCause();
+		String errorMessage = e.getMessage();
+		if (mostSpecificCause != null) {
+			errorMessage = mostSpecificCause.getMessage();
+		}
+		return BaseResponse.error(BAD_REQUEST_ERROR.getCode(), errorMessage);
 	}
 
 	/**

--- a/be/src/main/java/com/example/be/common/exception/member/InvalidMemberTypeException.java
+++ b/be/src/main/java/com/example/be/common/exception/member/InvalidMemberTypeException.java
@@ -1,0 +1,11 @@
+package com.example.be.common.exception.member;
+
+import com.example.be.common.exception.BaseException;
+import com.example.be.common.exception.ErrorCodeAndMessages;
+
+public class InvalidMemberTypeException extends BaseException {
+
+	public InvalidMemberTypeException() {
+		super(ErrorCodeAndMessages.MEMBER_TYPE_ERROR);
+	}
+}

--- a/be/src/main/java/com/example/be/common/exception/member/InvalidSpeakingTestType.java
+++ b/be/src/main/java/com/example/be/common/exception/member/InvalidSpeakingTestType.java
@@ -1,0 +1,11 @@
+package com.example.be.common.exception.member;
+
+import com.example.be.common.exception.BaseException;
+import com.example.be.common.exception.ErrorCodeAndMessages;
+
+public class InvalidSpeakingTestType extends BaseException {
+
+	public InvalidSpeakingTestType() {
+		super(ErrorCodeAndMessages.SPEAKING_TEST_TYPE_ERROR);
+	}
+}

--- a/be/src/main/java/com/example/be/common/exception/member/NotFoundMemberIdException.java
+++ b/be/src/main/java/com/example/be/common/exception/member/NotFoundMemberIdException.java
@@ -1,4 +1,4 @@
-package com.example.be.common.exception.speakinglog;
+package com.example.be.common.exception.member;
 
 import com.example.be.common.exception.BaseException;
 import com.example.be.common.exception.ErrorCodeAndMessages;

--- a/be/src/main/java/com/example/be/common/exception/member/goal/NotFoundGoalIdException.java
+++ b/be/src/main/java/com/example/be/common/exception/member/goal/NotFoundGoalIdException.java
@@ -1,0 +1,11 @@
+package com.example.be.common.exception.member.goal;
+
+import com.example.be.common.exception.BaseException;
+import com.example.be.common.exception.ErrorCodeAndMessages;
+
+public class NotFoundGoalIdException extends BaseException {
+
+	public NotFoundGoalIdException() {
+		super(ErrorCodeAndMessages.GOAL_ID_NOT_FOUND_ERROR);
+	}
+}

--- a/be/src/main/java/com/example/be/common/exception/member/grade/InvalidSpeakingGradeLanguageException.java
+++ b/be/src/main/java/com/example/be/common/exception/member/grade/InvalidSpeakingGradeLanguageException.java
@@ -1,0 +1,11 @@
+package com.example.be.common.exception.member.grade;
+
+import com.example.be.common.exception.BaseException;
+import com.example.be.common.exception.ErrorCodeAndMessages;
+
+public class InvalidSpeakingGradeLanguageException extends BaseException {
+
+	public InvalidSpeakingGradeLanguageException() {
+		super(ErrorCodeAndMessages.SPEAKING_GRADE_LANGUAGE_ERROR);
+	}
+}

--- a/be/src/main/java/com/example/be/common/exception/member/grade/InvalidSpeakingGradeLevelException.java
+++ b/be/src/main/java/com/example/be/common/exception/member/grade/InvalidSpeakingGradeLevelException.java
@@ -1,0 +1,11 @@
+package com.example.be.common.exception.member.grade;
+
+import com.example.be.common.exception.BaseException;
+import com.example.be.common.exception.ErrorCodeAndMessages;
+
+public class InvalidSpeakingGradeLevelException extends BaseException {
+
+	public InvalidSpeakingGradeLevelException() {
+		super(ErrorCodeAndMessages.SPEAKING_GRADE_LEVEL_ERROR);
+	}
+}

--- a/be/src/main/java/com/example/be/common/exception/member/subject/NotFoundSubjectIdException.java
+++ b/be/src/main/java/com/example/be/common/exception/member/subject/NotFoundSubjectIdException.java
@@ -1,0 +1,11 @@
+package com.example.be.common.exception.member.subject;
+
+import com.example.be.common.exception.BaseException;
+import com.example.be.common.exception.ErrorCodeAndMessages;
+
+public class NotFoundSubjectIdException extends BaseException {
+
+	public NotFoundSubjectIdException() {
+		super(ErrorCodeAndMessages.SUBJECT_ID_NOT_FOUND_ERROR);
+	}
+}

--- a/be/src/main/java/com/example/be/common/response/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/example/be/common/response/ResponseCodeAndMessages.java
@@ -33,6 +33,12 @@ public enum ResponseCodeAndMessages implements CodeAndMessages {
 	REISSUE_ACCESS_TOKEN_SUCCESS("S-OA002", "ACCESS TOKEN 재발급에 성공했습니다."),
 
 	/**
+	 * Member
+	 */
+	MEMBER_SIGN_UP_SUCCESS("S-M001", "멤버의 회원 등록에 성공했습니다."),
+	MEMBER_INFO_UPDATE_SUCCESS("S-M002", "멤버의 회원 정보 변경에 성공했습니다."),
+
+	/**
 	 Study
 	 */
 	CREATE_STUDY_SUCCESS("S-S001", "스터디 생성을 성공했습니다."),

--- a/be/src/main/java/com/example/be/common/response/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/example/be/common/response/ResponseCodeAndMessages.java
@@ -35,8 +35,8 @@ public enum ResponseCodeAndMessages implements CodeAndMessages {
 	/**
 	 * Member
 	 */
-	MEMBER_SIGN_UP_SUCCESS("S-M001", "멤버의 회원 등록에 성공했습니다."),
-	MEMBER_INFO_UPDATE_SUCCESS("S-M002", "멤버의 회원 정보 변경에 성공했습니다."),
+	SIGN_UP_MEMBER_SUCCESS("S-M001", "멤버의 회원 등록에 성공했습니다."),
+	MODIFY_MEMBER_INFO_SUCCESS("S-M002", "멤버의 회원 정보 변경에 성공했습니다."),
 
 	/**
 	 Study

--- a/be/src/main/java/com/example/be/core/application/AssignmentService.java
+++ b/be/src/main/java/com/example/be/core/application/AssignmentService.java
@@ -1,7 +1,7 @@
 package com.example.be.core.application;
 
 import com.example.be.common.exception.assignment.NotFoundAssignmentIdException;
-import com.example.be.common.exception.speakinglog.NotFoundMemberIdException;
+import com.example.be.common.exception.member.NotFoundMemberIdException;
 import com.example.be.common.exception.study.NotFoundStudyIdException;
 import com.example.be.core.application.dto.request.AssignmentRequest;
 import com.example.be.core.application.dto.response.AssignmentDetailResponse;
@@ -18,7 +18,6 @@ import com.example.be.core.repository.member.MemberRepository;
 import com.example.be.core.repository.study.StudyMemberRepository;
 import com.example.be.core.repository.study.StudyRepository;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/be/src/main/java/com/example/be/core/application/MemberService.java
+++ b/be/src/main/java/com/example/be/core/application/MemberService.java
@@ -1,0 +1,2 @@
+package com.example.be.core.application;public class MemberService {
+}

--- a/be/src/main/java/com/example/be/core/application/MemberService.java
+++ b/be/src/main/java/com/example/be/core/application/MemberService.java
@@ -20,7 +20,9 @@ import com.example.be.core.repository.member.goal.GoalRepository;
 import com.example.be.core.repository.member.grade.SpeakingGradeRepository;
 import com.example.be.core.repository.member.subject.SubjectMemberRepository;
 import com.example.be.core.repository.member.subject.SubjectRepository;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +30,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 public class MemberService {
+
+	private static final Long SPEAKING_TEST_GOAL_ID = 5L;
 
 	private final MemberRepository memberRepository;
 	private final SpeakingGradeRepository speakingGradeRepository;
@@ -53,9 +57,15 @@ public class MemberService {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(NotFoundMemberIdException::new);
 
+
+		if (hasNotSpeakingTestGoal(new HashSet<>(memberSignUpRequest.getGoals()))) {
+			memberSignUpRequest.updateSpeakingTestType(null);
+		}
+
 		member.signUp(
 			memberSignUpRequest.getMemberType(),
-			memberSignUpRequest.getAlarmStatus()
+			memberSignUpRequest.getAlarmStatus(),
+			memberSignUpRequest.getTestType()
 		);
 
 		SpeakingGrade learnerInfo = saveSpeakingGrade(
@@ -73,8 +83,13 @@ public class MemberService {
 			giverInfo.getLevel(),
 			getGoalResponses(memberSignUpRequest, member),
 			getSubjectResponses(memberSignUpRequest, member),
-			member.getAlarmStatus()
+			member.getAlarmStatus(),
+			member.getTestType()
 		);
+	}
+
+	private boolean hasNotSpeakingTestGoal(Set<Long> goals) {
+		return !goals.contains(SPEAKING_TEST_GOAL_ID);
 	}
 
 	private List<GoalResponse> getGoalResponses(MemberSignUpRequest memberSignUpRequest, Member member) {

--- a/be/src/main/java/com/example/be/core/application/MemberService.java
+++ b/be/src/main/java/com/example/be/core/application/MemberService.java
@@ -1,2 +1,130 @@
-package com.example.be.core.application;public class MemberService {
+package com.example.be.core.application;
+
+import com.example.be.common.exception.member.NotFoundMemberIdException;
+import com.example.be.common.exception.member.goal.NotFoundGoalIdException;
+import com.example.be.common.exception.member.subject.NotFoundSubjectIdException;
+import com.example.be.core.application.dto.request.MemberModifyRequest;
+import com.example.be.core.application.dto.request.MemberSignUpRequest;
+import com.example.be.core.application.dto.response.GoalResponse;
+import com.example.be.core.application.dto.response.MemberResponse;
+import com.example.be.core.application.dto.response.MemberSignUpResponse;
+import com.example.be.core.application.dto.response.SubjectResponse;
+import com.example.be.core.domain.member.Member;
+import com.example.be.core.domain.member.goal.GoalMember;
+import com.example.be.core.domain.member.grade.SpeakingGrade;
+import com.example.be.core.domain.member.grade.SpeakingGradeType;
+import com.example.be.core.domain.member.subject.SubjectMember;
+import com.example.be.core.repository.member.MemberRepository;
+import com.example.be.core.repository.member.goal.GoalMemberRepository;
+import com.example.be.core.repository.member.goal.GoalRepository;
+import com.example.be.core.repository.member.grade.SpeakingGradeRepository;
+import com.example.be.core.repository.member.subject.SubjectMemberRepository;
+import com.example.be.core.repository.member.subject.SubjectRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+	private final SpeakingGradeRepository speakingGradeRepository;
+	private final GoalRepository goalRepository;
+	private final GoalMemberRepository goalMemberRepository;
+	private final SubjectRepository subjectRepository;
+	private final SubjectMemberRepository subjectMemberRepository;
+
+	public MemberService(MemberRepository memberRepository,
+		SpeakingGradeRepository speakingGradeRepository, GoalRepository goalRepository,
+		GoalMemberRepository goalMemberRepository, SubjectRepository subjectRepository,
+		SubjectMemberRepository subjectMemberRepository) {
+		this.memberRepository = memberRepository;
+		this.speakingGradeRepository = speakingGradeRepository;
+		this.goalRepository = goalRepository;
+		this.goalMemberRepository = goalMemberRepository;
+		this.subjectRepository = subjectRepository;
+		this.subjectMemberRepository = subjectMemberRepository;
+	}
+
+	@Transactional
+	public MemberSignUpResponse signUp(Long memberId, MemberSignUpRequest memberSignUpRequest) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(NotFoundMemberIdException::new);
+
+		member.signUp(
+			memberSignUpRequest.getMemberType(),
+			memberSignUpRequest.getAlarmStatus()
+		);
+
+		SpeakingGrade learnerInfo = saveSpeakingGrade(
+			SpeakingGradeType.LEARNER, memberSignUpRequest, member);
+
+		SpeakingGrade giverInfo = saveSpeakingGrade(
+			SpeakingGradeType.GIVER, memberSignUpRequest, member);
+
+		return new MemberSignUpResponse(
+			member.getId(),
+			member.getMemberType(),
+			learnerInfo.getLanguage(),
+			learnerInfo.getLevel(),
+			giverInfo.getLanguage(),
+			giverInfo.getLevel(),
+			getGoalResponses(memberSignUpRequest, member),
+			getSubjectResponses(memberSignUpRequest, member),
+			member.getAlarmStatus()
+		);
+	}
+
+	private List<GoalResponse> getGoalResponses(MemberSignUpRequest memberSignUpRequest, Member member) {
+		return saveGoalMembers(memberSignUpRequest, member)
+			.stream().map(GoalMember::getGoal)
+			.map(GoalResponse::of)
+			.collect(Collectors.toList());
+	}
+
+	private List<SubjectResponse> getSubjectResponses(MemberSignUpRequest memberSignUpRequest,
+		Member member) {
+		return saveSubjectMembers(memberSignUpRequest, member)
+			.stream().map(SubjectMember::getSubject)
+			.map(SubjectResponse::of)
+			.collect(Collectors.toList());
+	}
+
+	private List<SubjectMember> saveSubjectMembers(MemberSignUpRequest memberSignUpRequest, Member member) {
+		return memberSignUpRequest.getSubjects()
+			.stream()
+			.map(subjectId -> subjectMemberRepository.save(
+				new SubjectMember(subjectRepository.findById(subjectId)
+					.orElseThrow(NotFoundSubjectIdException::new), member)))
+			.collect(Collectors.toList());
+	}
+
+	private List<GoalMember> saveGoalMembers(MemberSignUpRequest memberSignUpRequest, Member member) {
+		return memberSignUpRequest.getGoals()
+			.stream()
+			.map(goalId -> goalMemberRepository.save
+				(new GoalMember(goalRepository.findById(goalId)
+					.orElseThrow(NotFoundGoalIdException::new), member)))
+			.collect(Collectors.toList());
+	}
+
+	private SpeakingGrade saveSpeakingGrade(SpeakingGradeType type, MemberSignUpRequest request, Member member) {
+		if (type == SpeakingGradeType.LEARNER) {
+			return speakingGradeRepository.save(
+				new SpeakingGrade(type, request.getLearnerLanguage(),
+					request.getLearnerLevel(), member));
+		}
+		return speakingGradeRepository.save(
+			new SpeakingGrade(type, request.getGiverLanguage(),
+				request.getGiverLevel(), member));
+	}
+
+	@Transactional
+	public MemberResponse modify(Long memberId, MemberModifyRequest memberModifyRequest) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(NotFoundMemberIdException::new);
+		return null;
+	}
 }

--- a/be/src/main/java/com/example/be/core/application/SpeakingLogService.java
+++ b/be/src/main/java/com/example/be/core/application/SpeakingLogService.java
@@ -1,6 +1,6 @@
 package com.example.be.core.application;
 
-import com.example.be.common.exception.speakinglog.NotFoundMemberIdException;
+import com.example.be.common.exception.member.NotFoundMemberIdException;
 import com.example.be.common.exception.speakinglog.NotFoundSpeakingLogIdException;
 import com.example.be.core.application.dto.request.SpeakingLogConditionRequest;
 import com.example.be.core.application.dto.request.SpeakingLogModifyRequest;

--- a/be/src/main/java/com/example/be/core/application/StudyService.java
+++ b/be/src/main/java/com/example/be/core/application/StudyService.java
@@ -1,6 +1,6 @@
 package com.example.be.core.application;
 
-import com.example.be.common.exception.speakinglog.NotFoundMemberIdException;
+import com.example.be.common.exception.member.NotFoundMemberIdException;
 import com.example.be.common.exception.study.NotFoundStudyIdException;
 import com.example.be.core.application.dto.request.StudyConditionRequest;
 import com.example.be.core.application.dto.request.StudyRequest;

--- a/be/src/main/java/com/example/be/core/application/dto/request/MemberModifyRequest.java
+++ b/be/src/main/java/com/example/be/core/application/dto/request/MemberModifyRequest.java
@@ -1,0 +1,25 @@
+package com.example.be.core.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberModifyRequest {
+
+	@NotBlank(message = "닉네임이 빈 값이어서는 안됩니다.")
+	@Schema(type = "String", description = "변경할 닉네임, NOT NULL")
+	private String nickname;
+
+	@NotNull(message = "Profile Image 가 빈 값이어서는 안됩니다.")
+	@Pattern(regexp = "^(https?):\\/\\/([^:\\/\\s]+)(:([^\\/]*))?((\\/[^\\s/\\/]+)*)?\\/?([^#\\s\\?]*)(\\?([^#\\s]*))?(#(\\w*))?$",
+		message = "올바른 voiceRecord를 입력해야 합니다.")
+	@Schema(type = "String", description = "변경할 이미지, NOT NULL")
+	private String profileImage;
+}

--- a/be/src/main/java/com/example/be/core/application/dto/request/MemberModifyRequest.java
+++ b/be/src/main/java/com/example/be/core/application/dto/request/MemberModifyRequest.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.URL;
 import org.springframework.lang.Nullable;
 
 @Getter
@@ -18,8 +19,7 @@ public class MemberModifyRequest {
 	private String nickname;
 
 	@NotNull(message = "Profile Image 가 빈 값이어서는 안됩니다.")
-	@Pattern(regexp = "^(https?):\\/\\/([^:\\/\\s]+)(:([^\\/]*))?((\\/[^\\s/\\/]+)*)?\\/?([^#\\s\\?]*)(\\?([^#\\s]*))?(#(\\w*))?$",
-		message = "올바른 voiceRecord를 입력해야 합니다.")
+	@URL(message = "올바른 voiceRecord를 입력해야 합니다.")
 	@Schema(type = "String", description = "변경할 이미지, NOT NULL")
 	private String profileImage;
 }

--- a/be/src/main/java/com/example/be/core/application/dto/request/MemberSignUpRequest.java
+++ b/be/src/main/java/com/example/be/core/application/dto/request/MemberSignUpRequest.java
@@ -10,8 +10,10 @@ import javax.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
+@ToString
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberSignUpRequest {
 

--- a/be/src/main/java/com/example/be/core/application/dto/request/MemberSignUpRequest.java
+++ b/be/src/main/java/com/example/be/core/application/dto/request/MemberSignUpRequest.java
@@ -1,0 +1,77 @@
+package com.example.be.core.application.dto.request;
+
+import com.example.be.core.domain.member.MemberType;
+import com.example.be.core.domain.member.grade.SpeakingGradeLanguage;
+import com.example.be.core.domain.member.grade.SpeakingGradeLevel;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberSignUpRequest {
+
+	@NotNull(message = "memberType 을 정확히 입력해주세요. "
+		+ "elementary_school, middle_school, high_school, university, office_worker, job_seeker, free 중 하나여야 합니다.")
+	@Schema(type = "String", description = "멤버의 타입 선택, NOT NULL",
+		allowableValues = {"elementary_school", "middle_school", "high_school", "university",
+			"office_worker", "job_seeker", "free"})
+	private MemberType memberType;
+
+	@NotNull(message = "learnerLanguage 를 정확히 입력해주세요. "
+		+ "ENG, KOR 중 하나여야 합니다.")
+	@Schema(type = "String", description = "Learner Language 선택, NOT NULL",
+		allowableValues = {"ENG", "KOR"})
+	private SpeakingGradeLanguage learnerLanguage;
+
+	@NotNull(message = "learnerLevel 을 정확히 입력해주세요. "
+		+ "1, 2, 3, 4, 5 중 하나여야 합니다.")
+	@Schema(type = "String", description = "Learner Language Level, NOT NULL",
+		allowableValues = {"1", "2", "3", "4", "5"})
+	private SpeakingGradeLevel learnerLevel;
+
+	@NotNull(message = "giverLanguage 를 정확히 입력해주세요. "
+		+ "ENG, KOR 중 하나여야 합니다.")
+	@Schema(type = "String", description = "Giver Language 선택, NOT NULL",
+		allowableValues = {"ENG", "KOR"})
+	private SpeakingGradeLanguage giverLanguage;
+
+	@NotNull(message = "giverLevel 을 정확히 입력해주세요. "
+		+ "1, 2, 3, 4, 5 중 하나여야 합니다.")
+	@Schema(type = "String", description = "Giver Language Level, NOT NULL",
+		allowableValues = {"1", "2", "3", "4", "5"})
+	private SpeakingGradeLevel giverLevel;
+
+	@NotNull(message = "하나 이상의 목표가 선택되어야 합니다.")
+	@Size(min = 1, message = "하나 이상의 목표가 선택되어야 합니다.")
+	@Schema(type = "Array", minLength = 1,
+		description = "목표 다중 선택 가능(0부터 순서대로 기입, 1개 이상), NOT NULL")
+	private List<Long> goals;
+
+	@NotNull(message = "셋 이상의 주제가 선택되어야 합니다.")
+	@Size(min = 3, message = "셋 이상의 주제가 선택되어야 합니다.")
+	@Schema(type = "Array", minLength = 3,
+		description = "주제 다중 선택 가능(3개 이상), NOT NULL")
+	private List<Long> subjects;
+
+	@NotNull(message = "alarmStatus 를 정확히 입력해주세요. TRUE, FALSE 중 하나여야 합니다.")
+	@Schema(type = "Boolean")
+	private Boolean alarmStatus;
+
+	public MemberSignUpRequest(String memberType, String learnerLanguage,
+		String learnerLevel, String giverLanguage, String giverLevel, List<Long> goals,
+		List<Long> subjects, Boolean alarmStatus) {
+		this.memberType = MemberType.convert(memberType);
+		this.learnerLanguage = SpeakingGradeLanguage.convert(learnerLanguage);
+		this.learnerLevel = SpeakingGradeLevel.convert(learnerLevel);
+		this.giverLanguage = SpeakingGradeLanguage.convert(giverLanguage);
+		this.giverLevel = SpeakingGradeLevel.convert(giverLevel);
+		this.goals = goals;
+		this.subjects = subjects;
+		this.alarmStatus = alarmStatus;
+	}
+}

--- a/be/src/main/java/com/example/be/core/application/dto/request/MemberSignUpRequest.java
+++ b/be/src/main/java/com/example/be/core/application/dto/request/MemberSignUpRequest.java
@@ -19,45 +19,41 @@ public class MemberSignUpRequest {
 
 	@NotNull(message = "memberType 을 정확히 입력해주세요. "
 		+ "elementary_school, middle_school, high_school, university, office_worker, job_seeker, free 중 하나여야 합니다.")
-	@Schema(type = "String", description = "멤버의 타입 선택, NOT NULL",
-		allowableValues = {"elementary_school", "middle_school", "high_school", "university",
-			"office_worker", "job_seeker", "free"})
+	@Schema(enumAsRef = true, description = "멤버의 타입 선택, NOT NULL",
+		allowableValues = {"\"elementary_school\"", "\"middle_school\"", "\"high_school\"", "\"university\"", "\"office_worker\"", "\"job_seeker\"", "\"free\""})
 	private MemberType memberType;
 
 	@NotNull(message = "learnerLanguage 를 정확히 입력해주세요. "
 		+ "ENG, KOR 중 하나여야 합니다.")
-	@Schema(type = "String", description = "Learner Language 선택, NOT NULL",
-		allowableValues = {"ENG", "KOR"})
+	@Schema(enumAsRef = true, description = "Learner Language 선택, NOT NULL",
+		allowableValues = {"\"ENG\"", "\"KOR\""})
 	private SpeakingGradeLanguage learnerLanguage;
 
 	@NotNull(message = "learnerLevel 을 정확히 입력해주세요. "
 		+ "1, 2, 3, 4, 5 중 하나여야 합니다.")
-	@Schema(type = "String", description = "Learner Language Level, NOT NULL",
-		allowableValues = {"1", "2", "3", "4", "5"})
+	@Schema(enumAsRef = true, description = "Learner Language Level, NOT NULL",
+		allowableValues = {"\"1\"", "\"2\"", "\"3\"", "\"4\"", "\"5\""})
 	private SpeakingGradeLevel learnerLevel;
 
-	@NotNull(message = "giverLanguage 를 정확히 입력해주세요. "
-		+ "ENG, KOR 중 하나여야 합니다.")
-	@Schema(type = "String", description = "Giver Language 선택, NOT NULL",
-		allowableValues = {"ENG", "KOR"})
+	@NotNull(message = "giverLanguage 를 정확히 입력해주세요. ENG, KOR 중 하나여야 합니다.")
+	@Schema(enumAsRef = true, description = "Giver Language 선택, NOT NULL",
+		allowableValues = {"\"ENG\"", "\"KOR\""})
 	private SpeakingGradeLanguage giverLanguage;
 
 	@NotNull(message = "giverLevel 을 정확히 입력해주세요. "
 		+ "1, 2, 3, 4, 5 중 하나여야 합니다.")
-	@Schema(type = "String", description = "Giver Language Level, NOT NULL",
-		allowableValues = {"1", "2", "3", "4", "5"})
+	@Schema(enumAsRef = true, description = "Giver Language Level, NOT NULL",
+		allowableValues = {"\"1\"", "\"2\"", "\"3\"", "\"4\"", "\"5\""})
 	private SpeakingGradeLevel giverLevel;
 
 	@NotNull(message = "하나 이상의 목표가 선택되어야 합니다.")
 	@Size(min = 1, message = "하나 이상의 목표가 선택되어야 합니다.")
-	@Schema(type = "Array", minLength = 1,
-		description = "목표 다중 선택 가능(0부터 순서대로 기입, 1개 이상), NOT NULL")
+	@Schema(subTypes = {Long.class}, description = "목표 다중 선택 가능(0부터 순서대로 기입, 1개 이상), NOT NULL")
 	private List<Long> goals;
 
 	@NotNull(message = "셋 이상의 주제가 선택되어야 합니다.")
 	@Size(min = 3, message = "셋 이상의 주제가 선택되어야 합니다.")
-	@Schema(type = "Array", minLength = 3,
-		description = "주제 다중 선택 가능(3개 이상), NOT NULL")
+	@Schema(subTypes = {Long.class}, minLength = 3, description = "주제 다중 선택 가능(3개 이상), NOT NULL")
 	private List<Long> subjects;
 
 	@NotNull(message = "alarmStatus 를 정확히 입력해주세요. TRUE, FALSE 중 하나여야 합니다.")

--- a/be/src/main/java/com/example/be/core/application/dto/request/MemberSignUpRequest.java
+++ b/be/src/main/java/com/example/be/core/application/dto/request/MemberSignUpRequest.java
@@ -1,10 +1,13 @@
 package com.example.be.core.application.dto.request;
 
 import com.example.be.core.domain.member.MemberType;
+import com.example.be.core.domain.member.SpeakingTestType;
 import com.example.be.core.domain.member.grade.SpeakingGradeLanguage;
 import com.example.be.core.domain.member.grade.SpeakingGradeLevel;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.AccessLevel;
@@ -60,9 +63,13 @@ public class MemberSignUpRequest {
 	@Schema(type = "Boolean")
 	private Boolean alarmStatus;
 
+
+	@Schema(enumAsRef = true, description = "스피킹 시험의 종류(한 개만 선택 가능): OPIC, TOEFL, TOEIC_SPEAKING")
+	private SpeakingTestType testType;
+
 	public MemberSignUpRequest(String memberType, String learnerLanguage,
 		String learnerLevel, String giverLanguage, String giverLevel, List<Long> goals,
-		List<Long> subjects, Boolean alarmStatus) {
+		List<Long> subjects, Boolean alarmStatus, String testType) {
 		this.memberType = MemberType.convert(memberType);
 		this.learnerLanguage = SpeakingGradeLanguage.convert(learnerLanguage);
 		this.learnerLevel = SpeakingGradeLevel.convert(learnerLevel);
@@ -71,5 +78,10 @@ public class MemberSignUpRequest {
 		this.goals = goals;
 		this.subjects = subjects;
 		this.alarmStatus = alarmStatus;
+		this.testType = SpeakingTestType.convert(testType);
+	}
+
+	public void updateSpeakingTestType(String source) {
+		this.testType = SpeakingTestType.convert(source);
 	}
 }

--- a/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogModifyRequest.java
+++ b/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogModifyRequest.java
@@ -2,11 +2,11 @@ package com.example.be.core.application.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.URL;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -18,8 +18,7 @@ public class SpeakingLogModifyRequest {
 	private String title;
 
 	@NotNull(message = "voiceRecord가 빈 값이어서는 안됩니다.")
-	@Pattern(regexp = "^(https?):\\/\\/([^:\\/\\s]+)(:([^\\/]*))?((\\/[^\\s/\\/]+)*)?\\/?([^#\\s\\?]*)(\\?([^#\\s]*))?(#(\\w*))?$",
-		message = "올바른 voiceRecord를 입력해야 합니다.")
+	@URL(message = "올바른 voiceRecord를 입력해야 합니다.")
 	@Schema(type = "String", description = "변경할 음성 녹음 URL, NOT NULL")
 	private String voiceRecord;
 

--- a/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogRequest.java
+++ b/be/src/main/java/com/example/be/core/application/dto/request/SpeakingLogRequest.java
@@ -3,11 +3,11 @@ package com.example.be.core.application.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.URL;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -19,8 +19,7 @@ public class SpeakingLogRequest {
     private String title;
 
     @NotNull(message = "voiceRecord가 빈 값이어서는 안됩니다.")
-    @Pattern(regexp = "^(https?):\\/\\/([^:\\/\\s]+)(:([^\\/]*))?((\\/[^\\s/\\/]+)*)?\\/?([^#\\s\\?]*)(\\?([^#\\s]*))?(#(\\w*))?$",
-        message = "올바른 voiceRecord를 입력해야 합니다.")
+    @URL(message = "올바른 voiceRecord를 입력해야 합니다.")
     @Schema(type = "String", description = "음성 녹음 URL, NOT NULL")
     private String voiceRecord;
 

--- a/be/src/main/java/com/example/be/core/application/dto/response/GoalResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/GoalResponse.java
@@ -1,0 +1,20 @@
+package com.example.be.core.application.dto.response;
+
+import com.example.be.core.domain.member.goal.Goal;
+import lombok.Getter;
+
+@Getter
+public class GoalResponse {
+
+	private final Long goalId;
+	private final String content;
+
+	private GoalResponse(Long goalId, String content) {
+		this.goalId = goalId;
+		this.content = content;
+	}
+
+	public static GoalResponse of(Goal goal) {
+		return new GoalResponse(goal.getId(), goal.getContent());
+	}
+}

--- a/be/src/main/java/com/example/be/core/application/dto/response/MemberResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/MemberResponse.java
@@ -10,31 +10,25 @@ import lombok.Getter;
 public class MemberResponse {
 
   @Schema(type = "Long", description = "멤버 ID, NOT NULL")
-  @NotNull
-  @Positive
   private final Long memberId;
 
   @Schema(type = "String", description = "이름, NOT NULL")
-  @NotBlank
   private final String nickname;
 
-  @Schema(type = "String", description = "이메일, NOT NULL")
-  @NotBlank
+  @Schema(type = "String", description = "이메일, NULL")
   private final String email;
 
-  @Schema(type = "String", description = "비밀번호, NOT NULL")
-  @NotBlank
-  private final String password;
-
-  @Schema(type = "String", description = "프로필 이미지, NOT NULL")
+  @Schema(type = "String", description = "프로필 이미지, NULL")
   private final String profileImage;
 
-  public MemberResponse(Long memberId, String nickname, String email, String password, String profileImage) {
+  @Schema(type = "String", description = "유니크 ID")
+  private final String uniqueId;
+
+  public MemberResponse(Long memberId, String nickname, String email, String profileImage, String uniqueId) {
     this.memberId = memberId;
     this.nickname = nickname;
     this.email = email;
-    this.password = password;
     this.profileImage = profileImage;
+    this.uniqueId = uniqueId;
   }
-
 }

--- a/be/src/main/java/com/example/be/core/application/dto/response/MemberSignUpResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/MemberSignUpResponse.java
@@ -1,6 +1,7 @@
 package com.example.be.core.application.dto.response;
 
 import com.example.be.core.domain.member.MemberType;
+import com.example.be.core.domain.member.SpeakingTestType;
 import com.example.be.core.domain.member.grade.SpeakingGradeLanguage;
 import com.example.be.core.domain.member.grade.SpeakingGradeLevel;
 import java.util.List;
@@ -19,12 +20,13 @@ public class MemberSignUpResponse {
 	private final List<GoalResponse> goals;
 	private final List<SubjectResponse> subjects;
 	private final Boolean alarmStatus;
+	private final SpeakingTestType testType;
 
 	public MemberSignUpResponse(Long memberId, MemberType memberType,
 		SpeakingGradeLanguage learnerLanguage, SpeakingGradeLevel learnerLevel,
 		SpeakingGradeLanguage giverLanguage, SpeakingGradeLevel giverLevel,
-		List<GoalResponse> goals,
-		List<SubjectResponse> subjects, Boolean alarmStatus) {
+		List<GoalResponse> goals, List<SubjectResponse> subjects,
+		Boolean alarmStatus, SpeakingTestType testType) {
 		this.memberId = memberId;
 		this.memberType = memberType;
 		this.learnerLanguage = learnerLanguage;
@@ -34,5 +36,6 @@ public class MemberSignUpResponse {
 		this.goals = goals;
 		this.subjects = subjects;
 		this.alarmStatus = alarmStatus;
+		this.testType = testType;
 	}
 }

--- a/be/src/main/java/com/example/be/core/application/dto/response/MemberSignUpResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/MemberSignUpResponse.java
@@ -1,0 +1,39 @@
+package com.example.be.core.application.dto.response;
+
+import com.example.be.core.domain.member.MemberType;
+import com.example.be.core.domain.member.grade.SpeakingGradeLanguage;
+import com.example.be.core.domain.member.grade.SpeakingGradeLevel;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+public class MemberSignUpResponse {
+
+	private final Long memberId;
+	private final MemberType memberType;
+	private final SpeakingGradeLanguage learnerLanguage;
+	private final SpeakingGradeLevel learnerLevel;
+
+	private final SpeakingGradeLanguage giverLanguage;
+	private final SpeakingGradeLevel giverLevel;
+	private final List<GoalResponse> goals;
+	private final List<SubjectResponse> subjects;
+	private final Boolean alarmStatus;
+
+	public MemberSignUpResponse(Long memberId, MemberType memberType,
+		SpeakingGradeLanguage learnerLanguage, SpeakingGradeLevel learnerLevel,
+		SpeakingGradeLanguage giverLanguage, SpeakingGradeLevel giverLevel,
+		List<GoalResponse> goals,
+		List<SubjectResponse> subjects, Boolean alarmStatus) {
+		this.memberId = memberId;
+		this.memberType = memberType;
+		this.learnerLanguage = learnerLanguage;
+		this.learnerLevel = learnerLevel;
+		this.giverLanguage = giverLanguage;
+		this.giverLevel = giverLevel;
+		this.goals = goals;
+		this.subjects = subjects;
+		this.alarmStatus = alarmStatus;
+	}
+}

--- a/be/src/main/java/com/example/be/core/application/dto/response/MemberSignUpResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/MemberSignUpResponse.java
@@ -14,7 +14,6 @@ public class MemberSignUpResponse {
 	private final MemberType memberType;
 	private final SpeakingGradeLanguage learnerLanguage;
 	private final SpeakingGradeLevel learnerLevel;
-
 	private final SpeakingGradeLanguage giverLanguage;
 	private final SpeakingGradeLevel giverLevel;
 	private final List<GoalResponse> goals;

--- a/be/src/main/java/com/example/be/core/application/dto/response/SubjectResponse.java
+++ b/be/src/main/java/com/example/be/core/application/dto/response/SubjectResponse.java
@@ -1,0 +1,20 @@
+package com.example.be.core.application.dto.response;
+
+import com.example.be.core.domain.member.subject.Subject;
+import lombok.Getter;
+
+@Getter
+public class SubjectResponse {
+
+	private final Long subjectId;
+	private final String content;
+
+	private SubjectResponse(Long subjectId, String content) {
+		this.subjectId = subjectId;
+		this.content = content;
+	}
+
+	public static SubjectResponse of(Subject subject) {
+		return new SubjectResponse(subject.getId(), subject.getContent());
+	}
+}

--- a/be/src/main/java/com/example/be/core/domain/member/Follow.java
+++ b/be/src/main/java/com/example/be/core/domain/member/Follow.java
@@ -1,0 +1,27 @@
+package com.example.be.core.domain.member;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Follow {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Member followerId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Member followingId;
+}

--- a/be/src/main/java/com/example/be/core/domain/member/Member.java
+++ b/be/src/main/java/com/example/be/core/domain/member/Member.java
@@ -31,10 +31,10 @@ public class Member extends BaseEntity {
 	private String uniqueId;
 
 	private String profileImage;
-
 	private MemberType memberType;
 	private Boolean alarmStatus;
 	private Integer point;
+	private SpeakingTestType testType;
 
 	public Member(String nickname, String email, String uniqueId, String profileImage) {
 		this.nickname = nickname;
@@ -43,10 +43,11 @@ public class Member extends BaseEntity {
 		this.profileImage = profileImage;
 	}
 
-	public void signUp(MemberType memberType, Boolean alarmStatus) {
+	public void signUp(MemberType memberType, Boolean alarmStatus, SpeakingTestType testType) {
 		this.memberType = memberType;
 		this.alarmStatus = alarmStatus;
 		this.point = 0;
+		this.testType = testType;
 	}
 
 	public void updateProfileImage(String profileImage) {

--- a/be/src/main/java/com/example/be/core/domain/member/Member.java
+++ b/be/src/main/java/com/example/be/core/domain/member/Member.java
@@ -27,14 +27,29 @@ public class Member extends BaseEntity {
 	@Column(unique = true)
 	private String email;
 
+	@Column(unique = true)
 	private String uniqueId;
 
 	private String profileImage;
+
+	private MemberType memberType;
+	private Boolean alarmStatus;
+	private Integer point;
 
 	public Member(String nickname, String email, String uniqueId, String profileImage) {
 		this.nickname = nickname;
 		this.email = email;
 		this.uniqueId = uniqueId;
+		this.profileImage = profileImage;
+	}
+
+	public void signUp(MemberType memberType, Boolean alarmStatus) {
+		this.memberType = memberType;
+		this.alarmStatus = alarmStatus;
+		this.point = 0;
+	}
+
+	public void updateProfileImage(String profileImage) {
 		this.profileImage = profileImage;
 	}
 }

--- a/be/src/main/java/com/example/be/core/domain/member/MemberType.java
+++ b/be/src/main/java/com/example/be/core/domain/member/MemberType.java
@@ -1,0 +1,33 @@
+package com.example.be.core.domain.member;
+
+import com.example.be.common.exception.member.InvalidMemberTypeException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public enum MemberType {
+
+	ELEMENTARY_SCHOOL("elementary_school"),
+	MIDDLE_SCHOOL("middle_school"),
+	HIGH_SCHOOL("high_school"),
+	UNIVERSITY("university"),
+	OFFICE_WORKER("office_worker"),
+	JOB_SEEKER("job_seeker"),
+	FREE("free")
+	;
+
+	private final String type;
+
+	MemberType(String type) {
+		this.type = type;
+	}
+
+	@JsonCreator
+	public static MemberType convert(String source) {
+		return Arrays.stream(MemberType.values())
+			.filter(e -> e.type.equals(source.toLowerCase()))
+			.findAny()
+			.orElseThrow(InvalidMemberTypeException::new);
+	}
+}

--- a/be/src/main/java/com/example/be/core/domain/member/SpeakingTestType.java
+++ b/be/src/main/java/com/example/be/core/domain/member/SpeakingTestType.java
@@ -1,0 +1,31 @@
+package com.example.be.core.domain.member;
+
+import com.example.be.common.exception.member.InvalidSpeakingTestType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Arrays;
+import java.util.Set;
+
+public enum SpeakingTestType {
+
+	OPIC("OPIC"),
+	TOEFL("TOEFL"),
+	TOEIC_SPEAKING("TOEIC_SPEAKING");
+
+	private final String name;
+
+	SpeakingTestType(String name) {
+		this.name = name;
+	}
+
+	@JsonCreator
+	public static SpeakingTestType convert(String source) {
+		if (source == null) {
+			return null;
+		}
+
+		return Arrays.stream(values())
+			.filter(e -> e.name.equals(source.toUpperCase()))
+			.findAny()
+			.orElseThrow(InvalidSpeakingTestType::new);
+	}
+}

--- a/be/src/main/java/com/example/be/core/domain/member/goal/Goal.java
+++ b/be/src/main/java/com/example/be/core/domain/member/goal/Goal.java
@@ -17,4 +17,9 @@ public class Goal {
     private Long id;
 
     private String content;
+
+    public Goal(Long id, String content) {
+        this.id = id;
+        this.content = content;
+    }
 }

--- a/be/src/main/java/com/example/be/core/domain/member/goal/Goal.java
+++ b/be/src/main/java/com/example/be/core/domain/member/goal/Goal.java
@@ -1,10 +1,7 @@
-package com.example.be.core.domain.goal;
+package com.example.be.core.domain.member.goal;
 
-import com.example.be.core.domain.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -20,9 +17,4 @@ public class Goal {
     private Long id;
 
     private String content;
-
-    public Goal(Long id, String content) {
-        this.id = id;
-        this.content = content;
-    }
 }

--- a/be/src/main/java/com/example/be/core/domain/member/goal/GoalMember.java
+++ b/be/src/main/java/com/example/be/core/domain/member/goal/GoalMember.java
@@ -1,4 +1,4 @@
-package com.example.be.core.domain.goal;
+package com.example.be.core.domain.member.goal;
 
 import com.example.be.core.domain.member.Member;
 import javax.persistence.Column;
@@ -12,7 +12,6 @@ import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @Entity
@@ -25,15 +24,14 @@ public class GoalMember {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "goal_id")
+    private Goal goal;
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "goal_id")
-    private Goal goal;
-
-    public GoalMember(Member member, Goal goal) {
-        this.member = member;
+    public GoalMember(Goal goal, Member member) {
         this.goal = goal;
+        this.member = member;
     }
 }

--- a/be/src/main/java/com/example/be/core/domain/member/grade/SpeakingGrade.java
+++ b/be/src/main/java/com/example/be/core/domain/member/grade/SpeakingGrade.java
@@ -1,0 +1,41 @@
+package com.example.be.core.domain.member.grade;
+
+import com.example.be.core.domain.member.Member;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SpeakingGrade {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "speaking_grade_id")
+	private Long id;
+
+	private SpeakingGradeType type;
+
+	private SpeakingGradeLanguage language;
+
+	private SpeakingGradeLevel level;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Member member;
+
+	public SpeakingGrade(SpeakingGradeType type, SpeakingGradeLanguage language,
+		SpeakingGradeLevel level, Member member) {
+		this.type = type;
+		this.language = language;
+		this.level = level;
+		this.member = member;
+	}
+}

--- a/be/src/main/java/com/example/be/core/domain/member/grade/SpeakingGradeLanguage.java
+++ b/be/src/main/java/com/example/be/core/domain/member/grade/SpeakingGradeLanguage.java
@@ -19,7 +19,7 @@ public enum SpeakingGradeLanguage {
 
 	@JsonCreator
 	public static SpeakingGradeLanguage convert(String source) {
-		return Arrays.stream(SpeakingGradeLanguage.values())
+		return Arrays.stream(values())
 			.filter(e -> e.language.equals(source.toLowerCase()))
 			.findAny()
 			.orElseThrow(InvalidSpeakingGradeLanguageException::new);

--- a/be/src/main/java/com/example/be/core/domain/member/grade/SpeakingGradeLanguage.java
+++ b/be/src/main/java/com/example/be/core/domain/member/grade/SpeakingGradeLanguage.java
@@ -1,0 +1,27 @@
+package com.example.be.core.domain.member.grade;
+
+import com.example.be.common.exception.member.grade.InvalidSpeakingGradeLanguageException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public enum SpeakingGradeLanguage {
+
+	ENG("eng"),
+	KOR("kor");
+
+	private final String language;
+
+	SpeakingGradeLanguage(String language) {
+		this.language = language;
+	}
+
+	@JsonCreator
+	public static SpeakingGradeLanguage convert(String source) {
+		return Arrays.stream(SpeakingGradeLanguage.values())
+			.filter(e -> e.language.equals(source.toLowerCase()))
+			.findAny()
+			.orElseThrow(InvalidSpeakingGradeLanguageException::new);
+	}
+}

--- a/be/src/main/java/com/example/be/core/domain/member/grade/SpeakingGradeLevel.java
+++ b/be/src/main/java/com/example/be/core/domain/member/grade/SpeakingGradeLevel.java
@@ -3,6 +3,8 @@ package com.example.be.core.domain.member.grade;
 import com.example.be.common.exception.member.grade.InvalidSpeakingGradeLevelException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.Getter;
 
 @Getter
@@ -22,7 +24,15 @@ public enum SpeakingGradeLevel {
 
 	@JsonCreator
 	public static SpeakingGradeLevel convert(String source) {
-		return Arrays.stream(SpeakingGradeLevel.values())
+		Set<String> stringValues = Arrays.stream(SpeakingGradeLevel.values())
+			.map(Enum::toString)
+			.collect(Collectors.toSet());
+
+		if (stringValues.contains(source)) {
+			return SpeakingGradeLevel.valueOf(source);
+		}
+
+		return Arrays.stream(values())
 			.filter(e -> e.level.equals(source))
 			.findAny()
 			.orElseThrow(InvalidSpeakingGradeLevelException::new);

--- a/be/src/main/java/com/example/be/core/domain/member/grade/SpeakingGradeLevel.java
+++ b/be/src/main/java/com/example/be/core/domain/member/grade/SpeakingGradeLevel.java
@@ -1,0 +1,30 @@
+package com.example.be.core.domain.member.grade;
+
+import com.example.be.common.exception.member.grade.InvalidSpeakingGradeLevelException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public enum SpeakingGradeLevel {
+
+	LEVEL_ONE("1"),
+	LEVEL_TWO("2"),
+	LEVEL_THREE("3"),
+	LEVEL_FOUR("4"),
+	LEVEL_FIVE("5");
+
+	private final String level;
+
+	SpeakingGradeLevel(String level) {
+		this.level = level;
+	}
+
+	@JsonCreator
+	public static SpeakingGradeLevel convert(String source) {
+		return Arrays.stream(SpeakingGradeLevel.values())
+			.filter(e -> e.level.equals(source))
+			.findAny()
+			.orElseThrow(InvalidSpeakingGradeLevelException::new);
+	}
+}

--- a/be/src/main/java/com/example/be/core/domain/member/grade/SpeakingGradeTier.java
+++ b/be/src/main/java/com/example/be/core/domain/member/grade/SpeakingGradeTier.java
@@ -1,0 +1,16 @@
+package com.example.be.core.domain.member.grade;
+
+import lombok.Getter;
+
+@Getter
+public enum SpeakingGradeTier {
+
+	NORMAL("일반"),
+	EXPERT("고수");
+
+	private final String tier;
+
+	SpeakingGradeTier(String tier) {
+		this.tier = tier;
+	}
+}

--- a/be/src/main/java/com/example/be/core/domain/member/grade/SpeakingGradeType.java
+++ b/be/src/main/java/com/example/be/core/domain/member/grade/SpeakingGradeType.java
@@ -1,0 +1,15 @@
+package com.example.be.core.domain.member.grade;
+
+import lombok.Getter;
+
+@Getter
+public enum SpeakingGradeType {
+
+	LEARNER("LEARNER"), GIVER("GIVER");
+
+	private final String type;
+
+	SpeakingGradeType(String type) {
+		this.type = type;
+	}
+}

--- a/be/src/main/java/com/example/be/core/domain/member/subject/Subject.java
+++ b/be/src/main/java/com/example/be/core/domain/member/subject/Subject.java
@@ -20,4 +20,9 @@ public class Subject {
 	private Long id;
 
 	private String content;
+
+	public Subject(Long id, String content) {
+		this.id = id;
+		this.content = content;
+	}
 }

--- a/be/src/main/java/com/example/be/core/domain/member/subject/Subject.java
+++ b/be/src/main/java/com/example/be/core/domain/member/subject/Subject.java
@@ -1,0 +1,23 @@
+package com.example.be.core.domain.member.subject;
+
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Subject {
+
+	@Id
+	@Column(name = "subject_id")
+	private Long id;
+
+	private String content;
+}

--- a/be/src/main/java/com/example/be/core/domain/member/subject/SubjectMember.java
+++ b/be/src/main/java/com/example/be/core/domain/member/subject/SubjectMember.java
@@ -1,0 +1,38 @@
+package com.example.be.core.domain.member.subject;
+
+import com.example.be.core.domain.member.Member;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SubjectMember {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "subject_id")
+	private Subject subject;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	public SubjectMember(Subject subject, Member member) {
+		this.subject = subject;
+		this.member = member;
+	}
+
+}

--- a/be/src/main/java/com/example/be/core/repository/member/MemberRepository.java
+++ b/be/src/main/java/com/example/be/core/repository/member/MemberRepository.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
   	Optional<Member> findByEmail(String email);

--- a/be/src/main/java/com/example/be/core/repository/member/goal/GoalMemberRepository.java
+++ b/be/src/main/java/com/example/be/core/repository/member/goal/GoalMemberRepository.java
@@ -1,0 +1,8 @@
+package com.example.be.core.repository.member.goal;
+
+import com.example.be.core.domain.member.goal.GoalMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GoalMemberRepository extends JpaRepository<GoalMember, Long> {
+
+}

--- a/be/src/main/java/com/example/be/core/repository/member/goal/GoalRepository.java
+++ b/be/src/main/java/com/example/be/core/repository/member/goal/GoalRepository.java
@@ -1,0 +1,8 @@
+package com.example.be.core.repository.member.goal;
+
+import com.example.be.core.domain.member.goal.Goal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GoalRepository extends JpaRepository<Goal, Long> {
+
+}

--- a/be/src/main/java/com/example/be/core/repository/member/grade/SpeakingGradeRepository.java
+++ b/be/src/main/java/com/example/be/core/repository/member/grade/SpeakingGradeRepository.java
@@ -1,0 +1,8 @@
+package com.example.be.core.repository.member.grade;
+
+import com.example.be.core.domain.member.grade.SpeakingGrade;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpeakingGradeRepository extends JpaRepository<SpeakingGrade, Long> {
+
+}

--- a/be/src/main/java/com/example/be/core/repository/member/subject/SubjectMemberRepository.java
+++ b/be/src/main/java/com/example/be/core/repository/member/subject/SubjectMemberRepository.java
@@ -1,0 +1,8 @@
+package com.example.be.core.repository.member.subject;
+
+import com.example.be.core.domain.member.subject.SubjectMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubjectMemberRepository extends JpaRepository<SubjectMember, Long> {
+
+}

--- a/be/src/main/java/com/example/be/core/repository/member/subject/SubjectRepository.java
+++ b/be/src/main/java/com/example/be/core/repository/member/subject/SubjectRepository.java
@@ -1,0 +1,8 @@
+package com.example.be.core.repository.member.subject;
+
+import com.example.be.core.domain.member.subject.Subject;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubjectRepository extends JpaRepository<Subject, Long> {
+
+}

--- a/be/src/main/java/com/example/be/core/repository/speakinglog/CommentRepository.java
+++ b/be/src/main/java/com/example/be/core/repository/speakinglog/CommentRepository.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 	Integer countBySpeakingLogId(Long speakingLogId);

--- a/be/src/main/java/com/example/be/core/repository/speakinglog/FavoriteRepository.java
+++ b/be/src/main/java/com/example/be/core/repository/speakinglog/FavoriteRepository.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
 	Integer countBySpeakingLogId(Long speakingLogId);

--- a/be/src/main/java/com/example/be/core/repository/speakinglog/SpeakingLogRepository.java
+++ b/be/src/main/java/com/example/be/core/repository/speakinglog/SpeakingLogRepository.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
 public interface SpeakingLogRepository extends JpaRepository<SpeakingLog, Long> {
 
     List<SpeakingLog> findAllByCreatedAtBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);

--- a/be/src/main/java/com/example/be/core/web/MemberController.java
+++ b/be/src/main/java/com/example/be/core/web/MemberController.java
@@ -1,13 +1,52 @@
 package com.example.be.core.web;
 
+import static com.example.be.common.response.ResponseCodeAndMessages.MEMBER_INFO_UPDATE_SUCCESS;
+import static com.example.be.common.response.ResponseCodeAndMessages.MEMBER_SIGN_UP_SUCCESS;
+
+import com.example.be.common.response.BaseResponse;
+import com.example.be.core.application.MemberService;
+import com.example.be.core.application.dto.request.MemberModifyRequest;
+import com.example.be.core.application.dto.request.MemberSignUpRequest;
+import com.example.be.core.application.dto.response.MemberResponse;
+import com.example.be.core.application.dto.response.MemberSignUpResponse;
+import com.example.be.oauth.Login;
+import io.swagger.annotations.ApiOperation;
+import javax.validation.Valid;
+import javax.validation.constraints.Positive;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 
+@Validated
 @RestController
 @RequestMapping("/member")
 public class MemberController {
 
+	private final MemberService memberService;
+
+	public MemberController(MemberService memberService) {
+		this.memberService = memberService;
+	}
+
+	@PostMapping
+	@ApiOperation(value = "멤버의 회원 등록입니다.")
+	public BaseResponse<MemberSignUpResponse> signUp(@Login @Positive final Long memberId,
+		@RequestBody @Valid final MemberSignUpRequest memberSignUpRequest) {
+		MemberSignUpResponse response = memberService.signUp(memberId, memberSignUpRequest);
+		return new BaseResponse<>(MEMBER_SIGN_UP_SUCCESS, response);
+	}
+
+	@PutMapping
+	@ApiOperation(value = "멤버의 회원 정보 수정입니다.")
+	public BaseResponse<MemberResponse> modify(@Login @Positive final Long memberId,
+		@RequestBody @Valid final MemberModifyRequest memberModifyRequest) {
+		MemberResponse response = memberService.modify(memberId, memberModifyRequest);
+		return new BaseResponse<>(MEMBER_INFO_UPDATE_SUCCESS, response);
+	}
 
 }
 

--- a/be/src/main/java/com/example/be/core/web/MemberController.java
+++ b/be/src/main/java/com/example/be/core/web/MemberController.java
@@ -1,7 +1,7 @@
 package com.example.be.core.web;
 
-import static com.example.be.common.response.ResponseCodeAndMessages.MEMBER_INFO_UPDATE_SUCCESS;
-import static com.example.be.common.response.ResponseCodeAndMessages.MEMBER_SIGN_UP_SUCCESS;
+import static com.example.be.common.response.ResponseCodeAndMessages.MODIFY_MEMBER_INFO_SUCCESS;
+import static com.example.be.common.response.ResponseCodeAndMessages.SIGN_UP_MEMBER_SUCCESS;
 
 import com.example.be.common.response.BaseResponse;
 import com.example.be.core.application.MemberService;
@@ -37,7 +37,7 @@ public class MemberController {
 	public BaseResponse<MemberSignUpResponse> signUp(@Login @Positive final Long memberId,
 		@RequestBody @Valid final MemberSignUpRequest memberSignUpRequest) {
 		MemberSignUpResponse response = memberService.signUp(memberId, memberSignUpRequest);
-		return new BaseResponse<>(MEMBER_SIGN_UP_SUCCESS, response);
+		return new BaseResponse<>(SIGN_UP_MEMBER_SUCCESS, response);
 	}
 
 	@PutMapping
@@ -45,7 +45,7 @@ public class MemberController {
 	public BaseResponse<MemberResponse> modify(@Login @Positive final Long memberId,
 		@RequestBody @Valid final MemberModifyRequest memberModifyRequest) {
 		MemberResponse response = memberService.modify(memberId, memberModifyRequest);
-		return new BaseResponse<>(MEMBER_INFO_UPDATE_SUCCESS, response);
+		return new BaseResponse<>(MODIFY_MEMBER_INFO_SUCCESS, response);
 	}
 
 }

--- a/be/src/main/java/com/example/be/core/web/SpeakingLogController.java
+++ b/be/src/main/java/com/example/be/core/web/SpeakingLogController.java
@@ -13,6 +13,9 @@ import com.example.be.core.application.dto.request.SpeakingLogModifyRequest;
 import com.example.be.core.application.dto.request.SpeakingLogRequest;
 import com.example.be.core.application.dto.response.SpeakingLogDetailResponse;
 import com.example.be.core.application.dto.response.SpeakingLogsResponse;
+import com.example.be.oauth.Login;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
@@ -39,9 +42,9 @@ public class SpeakingLogController {
 
 	@PostMapping
 	@ApiOperation(value = "스피킹 로그 생성입니다.")
-	public BaseResponse<SpeakingLogDetailResponse> create(
+	public BaseResponse<SpeakingLogDetailResponse> create(@Login @Positive final Long memberId,
 		@RequestBody @Valid final SpeakingLogRequest speakingLogRequest) {
-		SpeakingLogDetailResponse response = speakingLogService.create(speakingLogRequest, 1L);
+		SpeakingLogDetailResponse response = speakingLogService.create(speakingLogRequest, memberId);
 		return new BaseResponse<>(CREATE_SPEAKING_LOG_SUCCESS, response);
 	}
 
@@ -55,9 +58,9 @@ public class SpeakingLogController {
 
 	@GetMapping("/{speakingLogId}")
 	@ApiOperation(value = "스피킹 로그 상세 조회입니다.")
-	public BaseResponse<SpeakingLogDetailResponse> findById(@PathVariable
-	@Positive(message = "SpeakingLog id 값은 항상 양수여야 합니다.") final Long speakingLogId) {
-		SpeakingLogDetailResponse response = speakingLogService.findById(speakingLogId, 1L);
+	public BaseResponse<SpeakingLogDetailResponse> findById(@Login @Positive final Long memberId,
+		@PathVariable @Positive(message = "SpeakingLog id 값은 항상 양수여야 합니다.") final Long speakingLogId) {
+		SpeakingLogDetailResponse response = speakingLogService.findById(speakingLogId, memberId);
 		return new BaseResponse<>(FIND_DETAIL_SPEAKING_LOG_SUCCESS, response);
 	}
 

--- a/be/src/main/java/com/example/be/oauth/controller/LoginController.java
+++ b/be/src/main/java/com/example/be/oauth/controller/LoginController.java
@@ -27,7 +27,7 @@ public class LoginController {
 	}
 
 	@GetMapping("/login/kakao")
-	@ApiOperation(value = "OAuth 로그인입니다. (현재는 카카오 로그인만 지원)")
+	@ApiOperation(value = "OAuth 로그인입니다. (현재는 카카오 로그인만 지원)", hidden = true)
 	public BaseResponse<LoginResponse> login(@RequestParam @NotBlank final String code) {
 		LoginResponse response = loginService.login(code);
 		return new BaseResponse<>(OAUTH_LOGIN_SUCCESS, response);

--- a/be/src/main/java/com/example/be/oauth/provider/LoginService.java
+++ b/be/src/main/java/com/example/be/oauth/provider/LoginService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class LoginService {
 
+	private static final String BASIC_PROFILE_IMAGE = "https://haru-speak-s3.s3.ap-northeast-2.amazonaws.com/image/b5ddbdeb-00bf-425a-9321-e36d25323bc0.jpg";
 	private final KakaoProvider kakaoProvider;
 	private final JwtProvider jwtProvider;
 	private final MemberRepository memberRepository;
@@ -38,6 +39,10 @@ public class LoginService {
 				memberInformation.getEmail(),
 				memberInformation.getUniqueId(),
 				memberInformation.getProfileImage())));
+
+		if (member.getProfileImage() == null) {
+			member.updateProfileImage(BASIC_PROFILE_IMAGE);
+		}
 
 		return new LoginResponse(
 			member.getId(),

--- a/be/src/main/resources/db/default-data.sql
+++ b/be/src/main/resources/db/default-data.sql
@@ -1,0 +1,48 @@
+SET AUTOCOMMIT = 0;
+
+-- GOAL
+INSERT INTO goal(goal_id, content)
+VALUES (1, '일상 속 유용한 표현 배우기!');
+
+INSERT INTO goal(goal_id, content)
+VALUES (2, '다른 사람들의 피드백!');
+
+INSERT INTO goal(goal_id, content)
+VALUES (3, '듣기 능력 키우기!');
+
+INSERT INTO goal(goal_id, content)
+VALUES (4, '함께 공부할 스터디 찾기!');
+
+INSERT INTO goal(goal_id, content)
+VALUES (5, '어학 자격증 따기!');
+
+-- SUBJECT
+INSERT INTO subject(subject_id, content)
+VALUES (1, '여행');
+
+INSERT INTO subject(subject_id, content)
+VALUES (2, '영화&음악');
+
+INSERT INTO subject(subject_id, content)
+VALUES (3, '일&회사');
+
+INSERT INTO subject(subject_id, content)
+VALUES (4, '쇼핑');
+
+INSERT INTO subject(subject_id, content)
+VALUES (5, '음식');
+
+INSERT INTO subject(subject_id, content)
+VALUES (6, '가족&친구');
+
+INSERT INTO subject(subject_id, content)
+VALUES (7, '운동&건강');
+
+INSERT INTO subject(subject_id, content)
+VALUES (8, '동네');
+
+INSERT INTO subject(subject_id, content)
+VALUES (9, '연애');
+
+SET AUTOCOMMIT = 1;
+

--- a/be/src/test/java/com/example/be/core/application/InitServiceTest.java
+++ b/be/src/test/java/com/example/be/core/application/InitServiceTest.java
@@ -6,11 +6,13 @@ import com.example.be.core.repository.speakinglog.SpeakingLogRepository;
 import com.example.be.core.repository.study.StudyMemberRepository;
 import com.example.be.core.repository.study.StudyRepository;
 import com.example.be.tool.DataBaseConfigurator;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+@Slf4j
 @SpringBootTest
 @ActiveProfiles("test")
 public abstract class InitServiceTest {
@@ -44,7 +46,10 @@ public abstract class InitServiceTest {
 
 	@BeforeEach
 	void setUpDataBase() {
+		log.info("[CLEAR DATA SOURCE]");
 		dbConfigurator.clear();
+		log.info("[INIT DATA SOURCE] BEFORE");
 		dbConfigurator.initDataSource();
+		log.info("[INIT DATA SOURCE] AFTER");
 	}
 }

--- a/be/src/test/java/com/example/be/core/application/member/MemberSignUpTest.java
+++ b/be/src/test/java/com/example/be/core/application/member/MemberSignUpTest.java
@@ -7,6 +7,7 @@ import com.example.be.core.application.MemberService;
 import com.example.be.core.application.dto.request.MemberSignUpRequest;
 import com.example.be.core.application.dto.response.MemberSignUpResponse;
 import com.example.be.core.domain.member.MemberType;
+import com.example.be.core.domain.member.SpeakingTestType;
 import com.example.be.core.domain.member.grade.SpeakingGradeLanguage;
 import com.example.be.core.domain.member.grade.SpeakingGradeLevel;
 import java.util.Arrays;
@@ -39,8 +40,8 @@ class MemberSignUpTest extends InitServiceTest {
 				List<Long> subjects = Arrays.asList(2L ,7L, 8L);
 
 				MemberSignUpRequest signUpRequest = new MemberSignUpRequest("university",
-					"eng", "4",
-					"kor", "2", goals, subjects, Boolean.FALSE);
+					"eng", "4", "kor", "2",
+					goals, subjects, Boolean.FALSE, "toefl");
 
 				//when
 				MemberSignUpResponse memberSignUpResponse = memberService.signUp(memberId, signUpRequest);
@@ -59,6 +60,7 @@ class MemberSignUpTest extends InitServiceTest {
 				assertThat(memberSignUpResponse.getGoals()).hasSize(2);
 				assertThat(memberSignUpResponse.getSubjects()).hasSize(3);
 				assertThat(memberSignUpResponse.getAlarmStatus()).isFalse();
+				assertThat(memberSignUpResponse.getTestType()).isNull();
 			}
 		}
 	}

--- a/be/src/test/java/com/example/be/core/application/member/MemberSignUpTest.java
+++ b/be/src/test/java/com/example/be/core/application/member/MemberSignUpTest.java
@@ -1,0 +1,69 @@
+package com.example.be.core.application.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.be.core.application.InitServiceTest;
+import com.example.be.core.application.MemberService;
+import com.example.be.core.application.dto.request.MemberSignUpRequest;
+import com.example.be.core.application.dto.response.MemberSignUpResponse;
+import com.example.be.core.domain.member.MemberType;
+import com.example.be.core.domain.member.grade.SpeakingGradeLanguage;
+import com.example.be.core.domain.member.grade.SpeakingGradeLevel;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@DisplayName("서비스 테스트 : Member 회원가입 테스트")
+public class MemberSignUpTest extends InitServiceTest {
+
+	@Autowired
+	private MemberService memberService;
+
+	@Nested
+	@DisplayName("정상적으로 Member 회원가입을 할 때")
+	class NormalSignUpTest {
+
+		@Nested
+		@DisplayName("MemberSignUpRequest 정보를 받아")
+		class ByMemberSignUpRequest {
+
+			@Test
+			@DisplayName("회원가입이 완료된다.")
+			void success_member_sign_up(){
+			    //given
+				Long memberId = 1L;
+				List<Long> goals = Arrays.asList(1L, 2L);
+				List<Long> subjects = Arrays.asList(2L ,7L, 8L);
+
+				MemberSignUpRequest signUpRequest = new MemberSignUpRequest("university",
+					"eng", "4",
+					"kor", "2", goals, subjects, Boolean.FALSE);
+
+				//when
+				MemberSignUpResponse memberSignUpResponse = memberService.signUp(memberId, signUpRequest);
+
+				//then
+				assertThat(memberSignUpResponse.getMemberId()).isEqualTo(memberId);
+				assertThat(memberSignUpResponse.getMemberType()).isEqualTo(MemberType.UNIVERSITY);
+				assertThat(memberSignUpResponse.getLearnerLanguage()).isEqualTo(
+					SpeakingGradeLanguage.ENG);
+				assertThat(memberSignUpResponse.getLearnerLevel()).isEqualTo(
+					SpeakingGradeLevel.LEVEL_FOUR);
+				assertThat(memberSignUpResponse.getGiverLanguage()).isEqualTo(
+					SpeakingGradeLanguage.KOR);
+				assertThat(memberSignUpResponse.getGiverLevel()).isEqualTo(
+					SpeakingGradeLevel.LEVEL_TWO);
+				assertThat(memberSignUpResponse.getGoals()).hasSize(2);
+				assertThat(memberSignUpResponse.getSubjects()).hasSize(3);
+				assertThat(memberSignUpResponse.getAlarmStatus()).isFalse();
+			}
+		}
+	}
+}

--- a/be/src/test/java/com/example/be/core/application/member/MemberSignUpTest.java
+++ b/be/src/test/java/com/example/be/core/application/member/MemberSignUpTest.java
@@ -9,19 +9,15 @@ import com.example.be.core.application.dto.response.MemberSignUpResponse;
 import com.example.be.core.domain.member.MemberType;
 import com.example.be.core.domain.member.grade.SpeakingGradeLanguage;
 import com.example.be.core.domain.member.grade.SpeakingGradeLevel;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
 @DisplayName("서비스 테스트 : Member 회원가입 테스트")
-public class MemberSignUpTest extends InitServiceTest {
+class MemberSignUpTest extends InitServiceTest {
 
 	@Autowired
 	private MemberService memberService;

--- a/be/src/test/java/com/example/be/core/application/s3/PreSignedUrlTest.java
+++ b/be/src/test/java/com/example/be/core/application/s3/PreSignedUrlTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.example.be.core.application.FileUploadService;
 import com.example.be.core.application.dto.response.PreSignedUrlResponse;
-import com.example.be.core.tool.AwsS3MockConfigurator;
+import com.example.be.tool.AwsS3MockConfigurator;
 import io.findify.s3mock.S3Mock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;

--- a/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogCreateTest.java
+++ b/be/src/test/java/com/example/be/core/application/speakinglog/SpeakingLogCreateTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.example.be.common.exception.BaseException;
-import com.example.be.common.exception.speakinglog.NotFoundMemberIdException;
+import com.example.be.common.exception.member.NotFoundMemberIdException;
 import com.example.be.core.application.InitServiceTest;
 import com.example.be.core.application.dto.request.SpeakingLogRequest;
 import com.example.be.core.application.dto.response.SpeakingLogDetailResponse;

--- a/be/src/test/java/com/example/be/core/web/InitControllerTest.java
+++ b/be/src/test/java/com/example/be/core/web/InitControllerTest.java
@@ -1,23 +1,24 @@
 package com.example.be.core.web;
 
-import com.example.be.common.config.WebConfig;
 import com.example.be.core.application.SpeakingLogService;
 import com.example.be.core.application.StudyService;
-import com.example.be.oauth.LoginArgumentResolver;
-import com.example.be.oauth.OAuthInterceptor;
-import com.example.be.oauth.config.properties.JwtProperties;
 import com.example.be.oauth.provider.JwtProvider;
+import com.example.be.tool.TestWebConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-@WebMvcTest(controllers = {SpeakingLogController.class, StudyController.class})
+@ActiveProfiles("test")
+@Import(TestWebConfig.class)
+@WebMvcTest(controllers = {SpeakingLogController.class, StudyController.class, MemberController.class})
 public abstract class InitControllerTest {
 
 	@MockBean
@@ -26,20 +27,14 @@ public abstract class InitControllerTest {
 	@MockBean
 	protected StudyService studyService;
 
-	@MockBean
-	protected WebConfig webConfig;
-
-	@MockBean
-	protected OAuthInterceptor oAuthInterceptor;
-
-	@MockBean
-	protected LoginArgumentResolver loginArgumentResolver;
-
 	@Autowired
 	protected MockMvc mockMvc;
 
 	@Autowired
 	protected ObjectMapper objectMapper;
+
+	@Autowired
+	protected JwtProvider jwtProvider;
 
 	@BeforeEach
 	void init(WebApplicationContext wc) {

--- a/be/src/test/java/com/example/be/core/web/InitControllerTest.java
+++ b/be/src/test/java/com/example/be/core/web/InitControllerTest.java
@@ -7,7 +7,6 @@ import com.example.be.tool.TestWebConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
@@ -18,7 +17,6 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 
 @ActiveProfiles("test")
 @Import(TestWebConfig.class)
-@WebMvcTest(controllers = {SpeakingLogController.class, StudyController.class, MemberController.class})
 public abstract class InitControllerTest {
 
 	@MockBean

--- a/be/src/test/java/com/example/be/core/web/InitControllerTest.java
+++ b/be/src/test/java/com/example/be/core/web/InitControllerTest.java
@@ -35,12 +35,6 @@ public abstract class InitControllerTest {
 	@MockBean
 	protected LoginArgumentResolver loginArgumentResolver;
 
-	@MockBean
-	protected JwtProvider jwtProvider;
-
-	@MockBean
-	protected JwtProperties jwtProperties;
-
 	@Autowired
 	protected MockMvc mockMvc;
 

--- a/be/src/test/java/com/example/be/core/web/member/MemberControllerSignUpTest.java
+++ b/be/src/test/java/com/example/be/core/web/member/MemberControllerSignUpTest.java
@@ -1,6 +1,6 @@
 package com.example.be.core.web.member;
 
-import static com.example.be.common.response.ResponseCodeAndMessages.MEMBER_SIGN_UP_SUCCESS;
+import static com.example.be.common.response.ResponseCodeAndMessages.SIGN_UP_MEMBER_SUCCESS;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -81,7 +81,8 @@ class MemberControllerSignUpTest extends InitControllerTest {
 					Boolean.FALSE
 				);
 
-				BaseResponse<MemberSignUpResponse> baseResponse = new BaseResponse<>(MEMBER_SIGN_UP_SUCCESS, response);
+				BaseResponse<MemberSignUpResponse> baseResponse = new BaseResponse<>(
+					SIGN_UP_MEMBER_SUCCESS, response);
 				when(memberService.signUp(refEq(memberId), refEq(request)))
 					.thenReturn(response);
 

--- a/be/src/test/java/com/example/be/core/web/member/MemberControllerSignUpTest.java
+++ b/be/src/test/java/com/example/be/core/web/member/MemberControllerSignUpTest.java
@@ -15,6 +15,7 @@ import com.example.be.core.application.dto.response.GoalResponse;
 import com.example.be.core.application.dto.response.MemberSignUpResponse;
 import com.example.be.core.application.dto.response.SubjectResponse;
 import com.example.be.core.domain.member.MemberType;
+import com.example.be.core.domain.member.SpeakingTestType;
 import com.example.be.core.domain.member.goal.Goal;
 import com.example.be.core.domain.member.grade.SpeakingGradeLanguage;
 import com.example.be.core.domain.member.grade.SpeakingGradeLevel;
@@ -56,8 +57,8 @@ class MemberControllerSignUpTest extends InitControllerTest {
 				List<Long> subjects = Arrays.asList(2L ,7L, 8L);
 
 				MemberSignUpRequest request = new MemberSignUpRequest("university",
-					"eng", "1",
-					"kor", "2", goals, subjects, Boolean.FALSE);
+					"eng", "1", "kor", "2",
+					goals, subjects, Boolean.FALSE, "opic");
 
 				List<GoalResponse> goalResponses = Arrays.asList(
 					GoalResponse.of(new Goal(1L, "일상 속 유용한 표현 배우기!")),
@@ -78,7 +79,8 @@ class MemberControllerSignUpTest extends InitControllerTest {
 					SpeakingGradeLevel.LEVEL_TWO,
 					goalResponses,
 					subjectResponses,
-					Boolean.FALSE
+					Boolean.FALSE,
+					SpeakingTestType.OPIC
 				);
 
 				BaseResponse<MemberSignUpResponse> baseResponse = new BaseResponse<>(

--- a/be/src/test/java/com/example/be/core/web/member/MemberControllerSignUpTest.java
+++ b/be/src/test/java/com/example/be/core/web/member/MemberControllerSignUpTest.java
@@ -20,16 +20,19 @@ import com.example.be.core.domain.member.grade.SpeakingGradeLanguage;
 import com.example.be.core.domain.member.grade.SpeakingGradeLevel;
 import com.example.be.core.domain.member.subject.Subject;
 import com.example.be.core.web.InitControllerTest;
+import com.example.be.core.web.MemberController;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 
+@WebMvcTest(MemberController.class)
 @DisplayName("컨트롤러 테스트 : Member 회원가입")
 class MemberControllerSignUpTest extends InitControllerTest {
 

--- a/be/src/test/java/com/example/be/core/web/member/MemberControllerSignUpTest.java
+++ b/be/src/test/java/com/example/be/core/web/member/MemberControllerSignUpTest.java
@@ -1,0 +1,99 @@
+package com.example.be.core.web.member;
+
+import static com.example.be.common.response.ResponseCodeAndMessages.MEMBER_SIGN_UP_SUCCESS;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.be.common.response.BaseResponse;
+import com.example.be.core.application.MemberService;
+import com.example.be.core.application.dto.request.MemberSignUpRequest;
+import com.example.be.core.application.dto.response.GoalResponse;
+import com.example.be.core.application.dto.response.MemberSignUpResponse;
+import com.example.be.core.application.dto.response.SubjectResponse;
+import com.example.be.core.domain.member.MemberType;
+import com.example.be.core.domain.member.goal.Goal;
+import com.example.be.core.domain.member.grade.SpeakingGradeLanguage;
+import com.example.be.core.domain.member.grade.SpeakingGradeLevel;
+import com.example.be.core.domain.member.subject.Subject;
+import com.example.be.core.web.InitControllerTest;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+
+@DisplayName("컨트롤러 테스트 : Member 회원가입")
+class MemberControllerSignUpTest extends InitControllerTest {
+
+	@MockBean
+	private MemberService memberService;
+
+	@Nested
+	@DisplayName("Member 회원가입을 할 때")
+	class SignUpTest {
+
+		@Nested
+		@DisplayName("정상적인 요청이라면")
+		class NormalTest {
+			
+			@Test
+			@DisplayName("멤버 회원가입시 해당 멤버의 정보가 업데이트 된다.")
+			void sign_up_member() throws Exception {
+			    //given
+				Long memberId = 1L;
+				List<Long> goals = Arrays.asList(1L, 2L);
+				List<Long> subjects = Arrays.asList(2L ,7L, 8L);
+
+				MemberSignUpRequest request = new MemberSignUpRequest("university",
+					"eng", "1",
+					"kor", "2", goals, subjects, Boolean.FALSE);
+
+				List<GoalResponse> goalResponses = Arrays.asList(
+					GoalResponse.of(new Goal(1L, "일상 속 유용한 표현 배우기!")),
+					GoalResponse.of(new Goal(2L, "다른 사람들의 피드백!"))
+				);
+				List<SubjectResponse> subjectResponses = Arrays.asList(
+					SubjectResponse.of(new Subject(2L, "영화&음악")),
+					SubjectResponse.of(new Subject(7L, "운동&건강")),
+					SubjectResponse.of(new Subject(8L, "동네"))
+				);
+
+				MemberSignUpResponse response = new MemberSignUpResponse(
+					memberId,
+					MemberType.UNIVERSITY,
+					SpeakingGradeLanguage.ENG,
+					SpeakingGradeLevel.LEVEL_FOUR,
+					SpeakingGradeLanguage.KOR,
+					SpeakingGradeLevel.LEVEL_TWO,
+					goalResponses,
+					subjectResponses,
+					Boolean.FALSE
+				);
+
+				BaseResponse<MemberSignUpResponse> baseResponse = new BaseResponse<>(MEMBER_SIGN_UP_SUCCESS, response);
+				when(memberService.signUp(refEq(memberId), refEq(request)))
+					.thenReturn(response);
+
+			    //when
+				ResultActions resultActions = mockMvc.perform(post("/member")
+					.header("Authorization", "Bearer "+jwtProvider.generateAccessToken(memberId))
+					.content(objectMapper.writeValueAsString(request))
+					.accept(MediaType.APPLICATION_JSON_VALUE)
+					.contentType(MediaType.APPLICATION_JSON_VALUE));
+
+				//then
+				resultActions.andExpect(status().isOk())
+					.andExpect(content().string(objectMapper.writeValueAsString(baseResponse)))
+					.andDo(print());
+			}
+		}
+	}
+}

--- a/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerCreateTest.java
+++ b/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerCreateTest.java
@@ -13,13 +13,16 @@ import com.example.be.common.response.BaseResponse;
 import com.example.be.core.application.dto.request.SpeakingLogRequest;
 import com.example.be.core.application.dto.response.SpeakingLogDetailResponse;
 import com.example.be.core.web.InitControllerTest;
+import com.example.be.core.web.SpeakingLogController;
 import java.util.ArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+@WebMvcTest(SpeakingLogController.class)
 @DisplayName("컨트롤러 테스트 : SpeakingLog 생성")
 class SpeakingLogControllerCreateTest extends InitControllerTest {
     @Nested
@@ -46,6 +49,7 @@ class SpeakingLogControllerCreateTest extends InitControllerTest {
 
                 //when
                 ResultActions resultActions = mockMvc.perform(post("/speaking-log")
+                    .header("Authorization", "Bearer "+jwtProvider.generateAccessToken(memberId))
                     .content(objectMapper.writeValueAsString(request))
                     .accept(MediaType.APPLICATION_JSON_VALUE)
                     .contentType(MediaType.APPLICATION_JSON_VALUE));

--- a/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerCreateTest.java
+++ b/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerCreateTest.java
@@ -24,7 +24,7 @@ import org.springframework.test.web.servlet.ResultActions;
 class SpeakingLogControllerCreateTest extends InitControllerTest {
     @Nested
     @DisplayName("Speaking Log 생성할 때")
-    class createTest {
+    class CreateTest {
 
         @Nested
         @DisplayName("정상적인 요청이라면")

--- a/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerDeleteTest.java
+++ b/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerDeleteTest.java
@@ -10,12 +10,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.example.be.common.response.BaseResponse;
 import com.example.be.core.web.InitControllerTest;
+import com.example.be.core.web.SpeakingLogController;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+@WebMvcTest(SpeakingLogController.class)
 @DisplayName("컨트롤러 테스트 : SpeakingLog 삭제")
 class SpeakingLogControllerDeleteTest extends InitControllerTest {
 
@@ -31,13 +34,15 @@ class SpeakingLogControllerDeleteTest extends InitControllerTest {
             @DisplayName("스피킹 로그 삭제시 해당 ID를 가진 스피킹 로그가 삭제된다")
             void delete_speaking_log() throws Exception {
                 //given
+                Long memberId = 1L;
                 Long speakingLogId = 1L;
                 BaseResponse<Void> baseResponse = new BaseResponse<>(DELETE_SPEAKING_LOG_SUCCESS, null);
 
                 //when
                 ResultActions resultActions = mockMvc.perform(delete("/speaking-log/{speakingLogId}", speakingLogId)
-                        .accept(MediaType.APPLICATION_JSON_VALUE)
-                        .contentType(MediaType.APPLICATION_JSON_VALUE));
+                    .header("Authorization", "Bearer "+jwtProvider.generateAccessToken(memberId))
+                    .accept(MediaType.APPLICATION_JSON_VALUE)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE));
 
                 //then
                 resultActions.andExpect(status().isOk())

--- a/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerDetailFindTest.java
+++ b/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerDetailFindTest.java
@@ -11,13 +11,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.example.be.common.response.BaseResponse;
 import com.example.be.core.application.dto.response.SpeakingLogDetailResponse;
 import com.example.be.core.web.InitControllerTest;
+import com.example.be.core.web.SpeakingLogController;
 import java.util.ArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+@WebMvcTest(SpeakingLogController.class)
 @DisplayName("컨트롤러 테스트 : SpeakingLog 상세 조회")
 class SpeakingLogControllerDetailFindTest extends InitControllerTest {
 
@@ -45,6 +48,7 @@ class SpeakingLogControllerDetailFindTest extends InitControllerTest {
 
 				//when
 				ResultActions resultActions = mockMvc.perform(get("/speaking-log/{speakingLogId}", speakingLogId)
+					.header("Authorization", "Bearer "+jwtProvider.generateAccessToken(memberId))
 					.accept(MediaType.APPLICATION_JSON_VALUE)
 					.contentType(MediaType.APPLICATION_JSON_VALUE));
 

--- a/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerFindByTypeTest.java
+++ b/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerFindByTypeTest.java
@@ -16,13 +16,16 @@ import com.example.be.core.application.dto.request.SpeakingLogConditionRequest;
 import com.example.be.core.application.dto.response.SpeakingLogsResponse;
 import com.example.be.core.domain.speakinglog.SpeakingLogType;
 import com.example.be.core.web.InitControllerTest;
+import com.example.be.core.web.SpeakingLogController;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+@WebMvcTest(SpeakingLogController.class)
 @DisplayName("컨트롤러 테스트 : SpeakingLog 전체 조회")
 class SpeakingLogControllerFindByTypeTest extends InitControllerTest {
 
@@ -42,6 +45,7 @@ class SpeakingLogControllerFindByTypeTest extends InitControllerTest {
 				@DisplayName("ALL TYPE 스피킹 로그 조회시 해당 날짜의 ALL TYPE 스피킹 로그가 조회된다")
 				void find_all_type_speaking_log_with_date() throws Exception {
 					//given
+					Long memberId = 1L;
 					SpeakingLogConditionRequest speakingLogConditionRequest = new SpeakingLogConditionRequest("all", "20230108");
 					SpeakingLogsResponse speakingLogsResponse = new SpeakingLogsResponse(SpeakingLogType.ALL, LocalDate.parse("20230108", BASIC_ISO_DATE),null);
 					BaseResponse<SpeakingLogsResponse> baseResponse = new BaseResponse<>(FIND_SPEAKING_LOG_SUCCESS, speakingLogsResponse);
@@ -51,6 +55,7 @@ class SpeakingLogControllerFindByTypeTest extends InitControllerTest {
 
 					//when
 					ResultActions resultActions = mockMvc.perform(get("/speaking-log?type=all&date=20230108")
+						.header("Authorization", "Bearer "+jwtProvider.generateAccessToken(memberId))
 						.accept(MediaType.APPLICATION_JSON_VALUE)
 						.contentType(MediaType.APPLICATION_JSON_VALUE));
 
@@ -66,6 +71,7 @@ class SpeakingLogControllerFindByTypeTest extends InitControllerTest {
 				@DisplayName("타입 없이 스피킹 로그 조회시 해당 날짜의 MY TYPE 스피킹 로그가 조회된다.")
 				void find_no_type_speaking_log_with_date() throws Exception {
 					//given
+					Long memberId = 1L;
 					SpeakingLogConditionRequest speakingLogConditionRequest = new SpeakingLogConditionRequest(null, "20230108");
 					SpeakingLogsResponse speakingLogsResponse = new SpeakingLogsResponse(SpeakingLogType.MY, LocalDate.parse("20230108", BASIC_ISO_DATE), null);
 					BaseResponse<SpeakingLogsResponse> baseResponse = new BaseResponse<>(FIND_SPEAKING_LOG_SUCCESS, speakingLogsResponse);
@@ -75,6 +81,7 @@ class SpeakingLogControllerFindByTypeTest extends InitControllerTest {
 
 					//when
 					ResultActions resultActions = mockMvc.perform(get("/speaking-log?date=20230108")
+						.header("Authorization", "Bearer "+jwtProvider.generateAccessToken(memberId))
 						.accept(MediaType.APPLICATION_JSON_VALUE)
 						.contentType(MediaType.APPLICATION_JSON_VALUE));
 
@@ -95,6 +102,7 @@ class SpeakingLogControllerFindByTypeTest extends InitControllerTest {
 				@DisplayName("ALL TYPE 스피킹 로그 조회시 오늘 날짜의 ALL TYPE 스피킹 로그가 조회된다")
 				void find_all_type_speaking_log_with_no_date() throws Exception {
 					//given
+					Long memberId = 1L;
 					SpeakingLogConditionRequest speakingLogConditionRequest = new SpeakingLogConditionRequest("all", null);
 					SpeakingLogsResponse speakingLogsResponse = new SpeakingLogsResponse(SpeakingLogType.ALL, LocalDate.now(), null);
 					BaseResponse<SpeakingLogsResponse> baseResponse = new BaseResponse<>(FIND_SPEAKING_LOG_SUCCESS, speakingLogsResponse);
@@ -104,6 +112,7 @@ class SpeakingLogControllerFindByTypeTest extends InitControllerTest {
 
 					//when
 					ResultActions resultActions = mockMvc.perform(get("/speaking-log?type=all")
+						.header("Authorization", "Bearer "+jwtProvider.generateAccessToken(memberId))
 						.accept(MediaType.APPLICATION_JSON_VALUE)
 						.contentType(MediaType.APPLICATION_JSON_VALUE));
 
@@ -119,6 +128,7 @@ class SpeakingLogControllerFindByTypeTest extends InitControllerTest {
 				@DisplayName("타입 없이 스피킹 로그 조회시 오늘 날짜의 MY TYPE 스피킹 로그가 조회된다")
 				void find_no_type_speaking_log_with_no_date() throws Exception {
 					//given
+					Long memberId = 1L;
 					SpeakingLogConditionRequest speakingLogConditionRequest = new SpeakingLogConditionRequest(null, null);
 					SpeakingLogsResponse speakingLogsResponse = new SpeakingLogsResponse(SpeakingLogType.MY, LocalDate.now(), null);
 					BaseResponse<SpeakingLogsResponse> baseResponse = new BaseResponse<>(FIND_SPEAKING_LOG_SUCCESS, speakingLogsResponse);
@@ -128,6 +138,7 @@ class SpeakingLogControllerFindByTypeTest extends InitControllerTest {
 
 					//when
 					ResultActions resultActions = mockMvc.perform(get("/speaking-log")
+						.header("Authorization", "Bearer "+jwtProvider.generateAccessToken(memberId))
 						.accept(MediaType.APPLICATION_JSON_VALUE)
 						.contentType(MediaType.APPLICATION_JSON_VALUE));
 
@@ -153,10 +164,12 @@ class SpeakingLogControllerFindByTypeTest extends InitControllerTest {
 				@DisplayName("스피킹 로그 조회시 Error가 발생한다.")
 				void find_wrong_type_speaking_log() throws Exception {
 					//given
+					Long memberId = 1L;
 					BaseResponse<SpeakingLogsResponse> baseResponse = new BaseResponse<>(SPEAKING_LOG_TYPE_ERROR, null);
 
 					//when
 					ResultActions resultActions = mockMvc.perform(get("/speaking-log?type=nathan")
+						.header("Authorization", "Bearer "+jwtProvider.generateAccessToken(memberId))
 						.accept(MediaType.APPLICATION_JSON_VALUE)
 						.contentType(MediaType.APPLICATION_JSON_VALUE));
 
@@ -174,10 +187,12 @@ class SpeakingLogControllerFindByTypeTest extends InitControllerTest {
 				@DisplayName("스피킹 로그 조회시 Error가 발생한다.")
 				void find_wrong_date_format_speaking_log() throws Exception {
 					//given
+					Long memberId = 1L;
 					BaseResponse<SpeakingLogsResponse> baseResponse = new BaseResponse<>(SPEAKING_LOG_DATE_FORMAT_ERROR, null);
 
 					//when
 					ResultActions resultActions = mockMvc.perform(get("/speaking-log?date=2023^^0108")
+						.header("Authorization", "Bearer "+jwtProvider.generateAccessToken(memberId))
 						.accept(MediaType.APPLICATION_JSON_VALUE)
 						.contentType(MediaType.APPLICATION_JSON_VALUE));
 

--- a/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerModifyTest.java
+++ b/be/src/test/java/com/example/be/core/web/speakinglog/SpeakingLogControllerModifyTest.java
@@ -12,13 +12,16 @@ import com.example.be.common.response.BaseResponse;
 import com.example.be.core.application.dto.request.SpeakingLogModifyRequest;
 import com.example.be.core.application.dto.response.SpeakingLogDetailResponse;
 import com.example.be.core.web.InitControllerTest;
+import com.example.be.core.web.SpeakingLogController;
 import java.util.ArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+@WebMvcTest(SpeakingLogController.class)
 @DisplayName("컨트롤러 테스트 : SpeakingLog 수정")
 class SpeakingLogControllerModifyTest extends InitControllerTest {
 
@@ -62,6 +65,7 @@ class SpeakingLogControllerModifyTest extends InitControllerTest {
                 //when
                 ResultActions resultActions = mockMvc.perform(
                     put("/speaking-log/{speakingLogId}", speakingLogId)
+                        .header("Authorization", "Bearer "+jwtProvider.generateAccessToken(memberId))
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .accept(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request)));

--- a/be/src/test/java/com/example/be/core/web/study/StudyControllerCreatTest.java
+++ b/be/src/test/java/com/example/be/core/web/study/StudyControllerCreatTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
-@DisplayName("컨트롤러 테스트 : 스터디 생성")
+@DisplayName("컨트롤러 테스트 : Study 생성")
 class StudyControllerCreatTest extends InitControllerTest {
 
   @Nested

--- a/be/src/test/java/com/example/be/core/web/study/StudyControllerCreatTest.java
+++ b/be/src/test/java/com/example/be/core/web/study/StudyControllerCreatTest.java
@@ -13,13 +13,16 @@ import com.example.be.common.response.BaseResponse;
 import com.example.be.core.application.dto.request.StudyRequest;
 import com.example.be.core.application.dto.response.StudyDetailResponse;
 import com.example.be.core.web.InitControllerTest;
+import com.example.be.core.web.StudyController;
 import java.util.ArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+@WebMvcTest(StudyController.class)
 @DisplayName("컨트롤러 테스트 : Study 생성")
 class StudyControllerCreatTest extends InitControllerTest {
 
@@ -48,6 +51,7 @@ class StudyControllerCreatTest extends InitControllerTest {
 
         //when
         ResultActions resultActions = mockMvc.perform(post("/study")
+            .header("Authorization", "Bearer "+jwtProvider.generateAccessToken(memberId))
             .content(objectMapper.writeValueAsString(request))
             .accept(MediaType.APPLICATION_JSON_VALUE)
             .contentType(MediaType.APPLICATION_JSON_VALUE));

--- a/be/src/test/java/com/example/be/core/web/study/StudyControllerDeleteTest.java
+++ b/be/src/test/java/com/example/be/core/web/study/StudyControllerDeleteTest.java
@@ -10,12 +10,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.example.be.common.response.BaseResponse;
 import com.example.be.core.web.InitControllerTest;
+import com.example.be.core.web.StudyController;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+@WebMvcTest(StudyController.class)
 @DisplayName("컨트롤러 테스트 : Study 삭제")
 class StudyControllerDeleteTest extends InitControllerTest {
 
@@ -31,11 +34,13 @@ class StudyControllerDeleteTest extends InitControllerTest {
       @DisplayName("스터디 삭제시 해당 ID를 가진 스터디가 삭제된다")
       void delete_study_log() throws Exception {
         //given
+        Long memberId = 1L;
         Long studyId = 1L;
         BaseResponse<Void> baseResponse = new BaseResponse<>(DELETE_STUDY_SUCCESS, null);
 
         //when
         ResultActions resultActions = mockMvc.perform(delete("/study/{studyId}", studyId)
+            .header("Authorization", "Bearer "+jwtProvider.generateAccessToken(memberId))
             .accept(MediaType.APPLICATION_JSON_VALUE)
             .contentType(MediaType.APPLICATION_JSON_VALUE));
 

--- a/be/src/test/java/com/example/be/core/web/study/StudyControllerDeleteTest.java
+++ b/be/src/test/java/com/example/be/core/web/study/StudyControllerDeleteTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
-@DisplayName("컨트롤러 테스트 : 스터디 삭제")
+@DisplayName("컨트롤러 테스트 : Study 삭제")
 class StudyControllerDeleteTest extends InitControllerTest {
 
   @Nested

--- a/be/src/test/java/com/example/be/core/web/study/StudyControllerDetailFindTest.java
+++ b/be/src/test/java/com/example/be/core/web/study/StudyControllerDetailFindTest.java
@@ -12,13 +12,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.example.be.common.response.BaseResponse;
 import com.example.be.core.application.dto.response.StudyDetailResponse;
 import com.example.be.core.web.InitControllerTest;
+import com.example.be.core.web.StudyController;
 import java.util.ArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+@WebMvcTest(StudyController.class)
 @DisplayName("컨트롤러 테스트 : Study 상세 조회")
 class StudyControllerDetailFindTest extends InitControllerTest {
 
@@ -34,6 +37,7 @@ class StudyControllerDetailFindTest extends InitControllerTest {
       @DisplayName("스터디 상세 조회시, 해당 ID를 가진 스터디가 조회된다.")
       void find_detail_study_log() throws Exception {
         //given
+        Long memberId = 1L;
         Long studyId = 1L;
         Integer likeCount = 10;
         StudyDetailResponse response = new StudyDetailResponse(studyId, "스터디 1", "스터디 1 입니다", 3, "english",
@@ -46,8 +50,9 @@ class StudyControllerDetailFindTest extends InitControllerTest {
 
         //when
         ResultActions resultActions = mockMvc.perform(get("/study/{studyId}", studyId)
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .contentType(MediaType.APPLICATION_JSON_VALUE));
+            .header("Authorization", "Bearer " + jwtProvider.generateAccessToken(memberId))
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE));
 
         //then
         resultActions.andExpect(status().isOk())

--- a/be/src/test/java/com/example/be/core/web/study/StudyControllerDetailFindTest.java
+++ b/be/src/test/java/com/example/be/core/web/study/StudyControllerDetailFindTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
-@DisplayName("컨트롤러 테스트 : 스터디 상세 조회")
+@DisplayName("컨트롤러 테스트 : Study 상세 조회")
 class StudyControllerDetailFindTest extends InitControllerTest {
 
   @Nested

--- a/be/src/test/java/com/example/be/core/web/study/StudyControllerFindByTypeTest.java
+++ b/be/src/test/java/com/example/be/core/web/study/StudyControllerFindByTypeTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
-@DisplayName("컨트롤러 테스트 : 스터디 전체 조회")
+@DisplayName("컨트롤러 테스트 : Study 전체 조회")
 class StudyControllerFindByTypeTest extends InitControllerTest {
 
   @Nested

--- a/be/src/test/java/com/example/be/core/web/study/StudyControllerFindByTypeTest.java
+++ b/be/src/test/java/com/example/be/core/web/study/StudyControllerFindByTypeTest.java
@@ -15,12 +15,15 @@ import com.example.be.common.response.BaseResponse;
 import com.example.be.core.application.dto.request.StudyConditionRequest;
 import com.example.be.core.application.dto.response.StudiesResponse;
 import com.example.be.core.web.InitControllerTest;
+import com.example.be.core.web.StudyController;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+@WebMvcTest(StudyController.class)
 @DisplayName("컨트롤러 테스트 : Study 전체 조회")
 class StudyControllerFindByTypeTest extends InitControllerTest {
 
@@ -36,6 +39,7 @@ class StudyControllerFindByTypeTest extends InitControllerTest {
       @DisplayName("ALL TYPE 스터디 조회시 ALL TYPE 스터디가 조회된다")
       void find_all_type_study() throws Exception {
         //given
+        Long memberId = 1L;
         StudyConditionRequest request = new StudyConditionRequest("all");
         StudiesResponse response = new StudiesResponse(ALL, null);
         BaseResponse<StudiesResponse> baseResponse = new BaseResponse<>(FIND_ALL_STUDY_SUCCESS, response);
@@ -45,6 +49,7 @@ class StudyControllerFindByTypeTest extends InitControllerTest {
 
         //when
         ResultActions resultActions = mockMvc.perform(get("/study?type=all")
+            .header("Authorization", "Bearer "+jwtProvider.generateAccessToken(memberId))
             .accept(MediaType.APPLICATION_JSON_VALUE)
             .contentType(MediaType.APPLICATION_JSON_VALUE));
 
@@ -60,6 +65,7 @@ class StudyControllerFindByTypeTest extends InitControllerTest {
       @DisplayName("타입 없이 스터디 조회시 MY TYPE 스터디가 조회된다")
       void find_no_type_study() throws Exception {
         //given
+        Long memberId = 1L;
         StudyConditionRequest request = new StudyConditionRequest(null);
         StudiesResponse response = new StudiesResponse(MY, null);
         BaseResponse<StudiesResponse> baseResponse = new BaseResponse<>(FIND_ALL_STUDY_SUCCESS, response);
@@ -69,6 +75,7 @@ class StudyControllerFindByTypeTest extends InitControllerTest {
 
         //when
         ResultActions resultActions = mockMvc.perform(get("/study")
+            .header("Authorization", "Bearer "+jwtProvider.generateAccessToken(memberId))
             .accept(MediaType.APPLICATION_JSON_VALUE)
             .contentType(MediaType.APPLICATION_JSON_VALUE));
 

--- a/be/src/test/java/com/example/be/core/web/study/StudyControllerModifyTest.java
+++ b/be/src/test/java/com/example/be/core/web/study/StudyControllerModifyTest.java
@@ -13,13 +13,16 @@ import com.example.be.common.response.BaseResponse;
 import com.example.be.core.application.dto.request.StudyRequest;
 import com.example.be.core.application.dto.response.StudyDetailResponse;
 import com.example.be.core.web.InitControllerTest;
+import com.example.be.core.web.StudyController;
 import java.util.ArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+@WebMvcTest(StudyController.class)
 @DisplayName("컨트롤러 테스트 : Study 수정")
 class StudyControllerModifyTest extends InitControllerTest {
 
@@ -50,9 +53,10 @@ class StudyControllerModifyTest extends InitControllerTest {
 
         //when
         ResultActions resultActions = mockMvc.perform(put("/study/{studyId}", studyId)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .content(objectMapper.writeValueAsString(request)));
+            .header("Authorization", "Bearer "+jwtProvider.generateAccessToken(memberId))
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .content(objectMapper.writeValueAsString(request)));
 
         //then
         resultActions.andExpect(status().isOk())

--- a/be/src/test/java/com/example/be/core/web/study/StudyControllerModifyTest.java
+++ b/be/src/test/java/com/example/be/core/web/study/StudyControllerModifyTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
-@DisplayName("컨트롤러 테스트 : 스터디 수정")
+@DisplayName("컨트롤러 테스트 : Study 수정")
 class StudyControllerModifyTest extends InitControllerTest {
 
 

--- a/be/src/test/java/com/example/be/tool/AwsS3MockConfigurator.java
+++ b/be/src/test/java/com/example/be/tool/AwsS3MockConfigurator.java
@@ -1,4 +1,4 @@
-package com.example.be.core.tool;
+package com.example.be.tool;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.AnonymousAWSCredentials;

--- a/be/src/test/java/com/example/be/tool/DataBaseConfigurator.java
+++ b/be/src/test/java/com/example/be/tool/DataBaseConfigurator.java
@@ -1,6 +1,6 @@
 package com.example.be.tool;
 
-import com.example.be.common.exception.speakinglog.NotFoundMemberIdException;
+import com.example.be.common.exception.member.NotFoundMemberIdException;
 import com.example.be.core.domain.assignment.Assignment;
 import com.example.be.core.domain.assignment.AssignmentMember;
 import com.example.be.core.domain.member.Member;

--- a/be/src/test/java/com/example/be/tool/DataBaseConfigurator.java
+++ b/be/src/test/java/com/example/be/tool/DataBaseConfigurator.java
@@ -4,12 +4,16 @@ import com.example.be.common.exception.member.NotFoundMemberIdException;
 import com.example.be.core.domain.assignment.Assignment;
 import com.example.be.core.domain.assignment.AssignmentMember;
 import com.example.be.core.domain.member.Member;
+import com.example.be.core.domain.member.goal.Goal;
+import com.example.be.core.domain.member.subject.Subject;
 import com.example.be.core.domain.speakinglog.SpeakingLog;
 import com.example.be.core.domain.study.Study;
 import com.example.be.core.domain.study.StudyMember;
 import com.example.be.core.repository.assignment.AssignmentMemberRepository;
 import com.example.be.core.repository.assignment.AssignmentRepository;
 import com.example.be.core.repository.member.MemberRepository;
+import com.example.be.core.repository.member.goal.GoalRepository;
+import com.example.be.core.repository.member.subject.SubjectRepository;
 import com.example.be.core.repository.speakinglog.SpeakingLogRepository;
 import com.example.be.core.repository.study.StudyMemberRepository;
 import com.example.be.core.repository.study.StudyRepository;
@@ -57,6 +61,12 @@ public class DataBaseConfigurator implements InitializingBean {
 	@Autowired
 	private AssignmentMemberRepository assignmentMemberRepository;
 
+	@Autowired
+	private GoalRepository goalRepository;
+
+	@Autowired
+	private SubjectRepository subjectRepository;
+
 	@PersistenceContext
 	private EntityManager entityManager;
 
@@ -71,7 +81,7 @@ public class DataBaseConfigurator implements InitializingBean {
 
 		List<String> tableNames = new ArrayList<>();
 		ResultSet tables = connection.getMetaData()
-				.getTables(connection.getCatalog(), null, null, new String[]{TABLE});
+			.getTables(connection.getCatalog(), null, null, new String[]{TABLE});
 
 		try (tables) {
 			while (tables.next()) {
@@ -101,6 +111,8 @@ public class DataBaseConfigurator implements InitializingBean {
 		initSpeakingLog();
 		initStudy();
 		initAssignment();
+		initGoal();
+		initSubject();
 	}
 
 	/**
@@ -109,12 +121,12 @@ public class DataBaseConfigurator implements InitializingBean {
 	private void initMember() {
 		for (int i = 1; i <= NUMBER_OF_MEMBER; i++) {
 			memberRepository.save(
-					new Member(
-							"member" + i,
-							"member-email" + i + "@google.com",
-							"password1234" + i,
-							"profileImage" + i
-					));
+				new Member(
+					"member" + i,
+					"member-email" + i + "@google.com",
+					"password1234" + i,
+					"profileImage" + i
+				));
 		}
 	}
 
@@ -124,16 +136,16 @@ public class DataBaseConfigurator implements InitializingBean {
 	private void initSpeakingLog() {
 		for (int i = 1; i <= NUMBER_OF_MEMBER; i++) {
 			Member member = memberRepository.findById((long) i)
-					.orElseThrow(NotFoundMemberIdException::new);
+				.orElseThrow(NotFoundMemberIdException::new);
 
 			for (int j = 1; j <= NUMBER_OF_SPEAKING_LOG; j++) {
 				speakingLogRepository.save(
-						new SpeakingLog(
-								member,
-								"speaking-log-title" + i + j,
-								"https://dummy-voice-record" + i + j,
-								"dummy-voice-text" + i + j
-						));
+					new SpeakingLog(
+						member,
+						"speaking-log-title" + i + j,
+						"https://dummy-voice-record" + i + j,
+						"dummy-voice-text" + i + j
+					));
 			}
 		}
 	}
@@ -157,7 +169,7 @@ public class DataBaseConfigurator implements InitializingBean {
 					"study-certificate" + i
 				));
 
-			for(int j = 1; j <= NUMBER_OF_MEMBER; j++) {
+			for (int j = 1; j <= NUMBER_OF_MEMBER; j++) {
 				Member member = memberRepository.findById((long) j)
 					.orElseThrow(NotFoundMemberIdException::new);
 				studyMemberRepository.save(
@@ -177,7 +189,7 @@ public class DataBaseConfigurator implements InitializingBean {
 		Study study = studyRepository.findById(1L).get();
 		List<StudyMember> studyMembers = studyMemberRepository.findStudyMembersByStudyId(
 			study.getId());
-		for(int i = 1; i <= NUMBER_OF_ASSIGNMENT; i++) {
+		for (int i = 1; i <= NUMBER_OF_ASSIGNMENT; i++) {
 			Assignment assignment = assignmentRepository.save(
 				new Assignment(
 					study,
@@ -187,7 +199,7 @@ public class DataBaseConfigurator implements InitializingBean {
 					"https://dummy-voice-record" + i
 				)
 			);
-			studyMembers.forEach( it ->
+			studyMembers.forEach(it ->
 				assignmentMemberRepository.save(
 					new AssignmentMember(
 						it.getMember(),
@@ -198,5 +210,34 @@ public class DataBaseConfigurator implements InitializingBean {
 				)
 			);
 		}
+	}
+
+	/**
+	 * [고정 데이터]
+	 * GOAL(목표)를 생성합니다.
+	 */
+
+	private void initGoal() {
+		goalRepository.save(new Goal(1L, "일상 속 유용한 표현 배우기!"));
+		goalRepository.save(new Goal(2L, "다른 사람들의 피드백!"));
+		goalRepository.save(new Goal(3L, "듣기 능력 키우기!"));
+		goalRepository.save(new Goal(4L, "함께 공부할 스터디 찾기!"));
+		goalRepository.save(new Goal(5L, "어학 자격증 따기!"));
+	}
+
+	/**
+	 * [고정 데이터] SUBJECT(주제)를 생성합니다.
+	 */
+
+	private void initSubject() {
+		subjectRepository.save(new Subject(1L, "여행"));
+		subjectRepository.save(new Subject(2L, "영화&음악"));
+		subjectRepository.save(new Subject(3L, "일&회사"));
+		subjectRepository.save(new Subject(4L, "쇼핑"));
+		subjectRepository.save(new Subject(5L, "음식"));
+		subjectRepository.save(new Subject(6L, "가족&친구"));
+		subjectRepository.save(new Subject(7L, "운동&건강"));
+		subjectRepository.save(new Subject(8L, "동네"));
+		subjectRepository.save(new Subject(9L, "연애"));
 	}
 }

--- a/be/src/test/java/com/example/be/tool/TestWebConfig.java
+++ b/be/src/test/java/com/example/be/tool/TestWebConfig.java
@@ -1,0 +1,42 @@
+package com.example.be.tool;
+
+import com.example.be.common.config.WebConfig;
+import com.example.be.oauth.LoginArgumentResolver;
+import com.example.be.oauth.OAuthInterceptor;
+import com.example.be.oauth.config.properties.JwtProperties;
+import com.example.be.oauth.provider.JwtProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+@TestConfiguration
+@EnableConfigurationProperties(value = {JwtProperties.class})
+public class TestWebConfig {
+
+	@Autowired
+	JwtProperties jwtProperties;
+
+	@Bean
+	WebConfig getWebconfig() {
+		return new WebConfig(getOAuthInterceptor(), getLoginArgumentResolver());
+	}
+
+	@Bean
+	@Primary
+	OAuthInterceptor getOAuthInterceptor() {
+		return new OAuthInterceptor(getJwtProvider());
+	}
+
+	@Bean
+	@Primary
+	LoginArgumentResolver getLoginArgumentResolver() {
+		return new LoginArgumentResolver(getJwtProvider());
+	}
+
+	@Bean
+	JwtProvider getJwtProvider() {
+		return new JwtProvider(jwtProperties);
+	}
+}


### PR DESCRIPTION
### ❗️ 이슈 번호

Related to #86 

<br><br>

### 📝 구현 내용

- 멤버 회원가입 기능 구현
- 멤버 회원가입 Web Layer, Service Layer Test 완료
- 모든 컨트롤러 테스트가 요청시 Header에 AccessToken 값을 포함하도록 리팩토링

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- 멤버 개인정보 수정 기능 구현 전, 스터디 도메인에 대한 기능 개발에 필요한 Goal, Subject 등을 먼저 main 브랜치에 병합하기 위해 끊어서 PR을 올립니다.
- 앞으로 컨트롤러 테스트시에 꼭 요청 헤더 값으로 AccessToken 값을 넣어주세요!


### Test 현황

<img width="536" alt="image" src="https://user-images.githubusercontent.com/67811880/216581324-b93b30c2-9ffb-4706-9b36-0b4e6173e56d.png">
