### PR TITLE
APP LOGIN 방식 추가(추후 리팩토링 필요)

### DIFF
--- a/be/src/main/java/com/example/be/oauth/config/KakaoAccountResponseDeserializer.java
+++ b/be/src/main/java/com/example/be/oauth/config/KakaoAccountResponseDeserializer.java
@@ -1,6 +1,6 @@
 package com.example.be.oauth.config;
 
-import com.example.be.oauth.provider.dto.KakaoAccountResponse;
+import com.example.be.oauth.provider.dto.response.KakaoAccountResponse;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;

--- a/be/src/main/java/com/example/be/oauth/controller/LoginController.java
+++ b/be/src/main/java/com/example/be/oauth/controller/LoginController.java
@@ -6,12 +6,16 @@ import static com.example.be.common.response.ResponseCodeAndMessages.REISSUE_ACC
 import com.example.be.common.response.BaseResponse;
 import com.example.be.oauth.Login;
 import com.example.be.oauth.provider.LoginService;
-import com.example.be.oauth.provider.dto.LoginResponse;
+import com.example.be.oauth.provider.dto.request.LoginRequest;
+import com.example.be.oauth.provider.dto.response.LoginResponse;
 import io.swagger.annotations.ApiOperation;
+import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Positive;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,9 +30,9 @@ public class LoginController {
 	}
 
 	@GetMapping("/login/kakao")
-	@ApiOperation(value = "OAuth 로그인입니다. (현재는 카카오 로그인만 지원)")
+	@ApiOperation(value = "[WEB] OAuth 로그인입니다. (현재는 카카오 로그인만 지원), (Test용)", hidden = true)
 	public BaseResponse<LoginResponse> login(@RequestParam @NotBlank final String code) {
-		LoginResponse response = loginService.login(code);
+		LoginResponse response = loginService.login(code, Boolean.FALSE);
 		return new BaseResponse<>(OAUTH_LOGIN_SUCCESS, response);
 	}
 
@@ -37,5 +41,12 @@ public class LoginController {
 	public BaseResponse<String> reIssueAccessToken(@Login @Positive final Long memberId) {
 		String response = loginService.reIssueAccessToken(memberId);
 		return new BaseResponse<>(REISSUE_ACCESS_TOKEN_SUCCESS, response);
+	}
+
+	@PostMapping("/app/login/kakao")
+	@ApiOperation(value = "[APP] OAuth 로그인입니다. (현재는 카카오 로그인만 지원)")
+	public BaseResponse<LoginResponse> appLogin(@RequestBody @Valid final LoginRequest loginRequest) {
+		LoginResponse response = loginService.login(loginRequest.getAccessToken(), Boolean.TRUE);
+		return new BaseResponse<>(OAUTH_LOGIN_SUCCESS, response);
 	}
 }

--- a/be/src/main/java/com/example/be/oauth/provider/KakaoProvider.java
+++ b/be/src/main/java/com/example/be/oauth/provider/KakaoProvider.java
@@ -3,8 +3,8 @@ package com.example.be.oauth.provider;
 import com.example.be.oauth.config.properties.KakaoProperties;
 import com.example.be.oauth.provider.client.KakaoMemberInfoClient;
 import com.example.be.oauth.provider.client.KakaoTokenClient;
-import com.example.be.oauth.provider.dto.KakaoAccessTokenResponse;
-import com.example.be.oauth.provider.dto.KakaoAccountResponse;
+import com.example.be.oauth.provider.dto.response.KakaoAccessTokenResponse;
+import com.example.be.oauth.provider.dto.response.KakaoAccountResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -23,11 +23,15 @@ public class KakaoProvider {
 	}
 
 
-	public KakaoAccountResponse getMemberInformation(String authorizeCode) {
-		KakaoAccessTokenResponse response = getAccessToken(authorizeCode);
-		return memberInfoClient.call(String.format("%s %s",
+	public KakaoAccountResponse getMemberInformation(String code, boolean appType) {
+		String accessToken = code;
+		if (!appType) {
+			KakaoAccessTokenResponse response = getAccessToken(code);
+			accessToken = response.getAccessToken();
+		}
+		return memberInfoClient.call(properties.getContentType(), String.format("%s %s",
 				properties.getTokenType(),
-				response.getAccessToken()));
+				accessToken));
 	}
 
 	private KakaoAccessTokenResponse getAccessToken(String authorizeCode) {

--- a/be/src/main/java/com/example/be/oauth/provider/LoginService.java
+++ b/be/src/main/java/com/example/be/oauth/provider/LoginService.java
@@ -2,8 +2,8 @@ package com.example.be.oauth.provider;
 
 import com.example.be.core.domain.member.Member;
 import com.example.be.core.repository.member.MemberRepository;
-import com.example.be.oauth.provider.dto.KakaoAccountResponse;
-import com.example.be.oauth.provider.dto.LoginResponse;
+import com.example.be.oauth.provider.dto.response.KakaoAccountResponse;
+import com.example.be.oauth.provider.dto.response.LoginResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,8 +25,8 @@ public class LoginService {
 	}
 
 	@Transactional
-	public LoginResponse login(final String code) {
-		KakaoAccountResponse memberInformation = kakaoProvider.getMemberInformation(code);
+	public LoginResponse login(final String code, final boolean appType) {
+		KakaoAccountResponse memberInformation = kakaoProvider.getMemberInformation(code, appType);
 		Boolean isNewbie = Boolean.FALSE;
 
 		if (!memberRepository.existsByUniqueId(memberInformation.getUniqueId())){

--- a/be/src/main/java/com/example/be/oauth/provider/client/KakaoMemberInfoClient.java
+++ b/be/src/main/java/com/example/be/oauth/provider/client/KakaoMemberInfoClient.java
@@ -1,6 +1,6 @@
 package com.example.be.oauth.provider.client;
 
-import com.example.be.oauth.provider.dto.KakaoAccountResponse;
+import com.example.be.oauth.provider.dto.response.KakaoAccountResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -10,6 +10,7 @@ public interface KakaoMemberInfoClient {
 
 	@GetMapping
 	KakaoAccountResponse call(
+		@RequestHeader("Content-Type") String contentType,
 		@RequestHeader("Authorization") String accessToken
 	);
 }

--- a/be/src/main/java/com/example/be/oauth/provider/client/KakaoTokenClient.java
+++ b/be/src/main/java/com/example/be/oauth/provider/client/KakaoTokenClient.java
@@ -1,6 +1,6 @@
 package com.example.be.oauth.provider.client;
 
-import com.example.be.oauth.provider.dto.KakaoAccessTokenResponse;
+import com.example.be.oauth.provider.dto.response.KakaoAccessTokenResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/be/src/main/java/com/example/be/oauth/provider/dto/request/LoginRequest.java
+++ b/be/src/main/java/com/example/be/oauth/provider/dto/request/LoginRequest.java
@@ -1,0 +1,14 @@
+package com.example.be.oauth.provider.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class LoginRequest {
+
+	@NotBlank
+	private String accessToken;
+}

--- a/be/src/main/java/com/example/be/oauth/provider/dto/response/KakaoAccessTokenResponse.java
+++ b/be/src/main/java/com/example/be/oauth/provider/dto/response/KakaoAccessTokenResponse.java
@@ -1,4 +1,4 @@
-package com.example.be.oauth.provider.dto;
+package com.example.be.oauth.provider.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;

--- a/be/src/main/java/com/example/be/oauth/provider/dto/response/KakaoAccountResponse.java
+++ b/be/src/main/java/com/example/be/oauth/provider/dto/response/KakaoAccountResponse.java
@@ -1,4 +1,4 @@
-package com.example.be.oauth.provider.dto;
+package com.example.be.oauth.provider.dto.response;
 
 import com.example.be.oauth.config.KakaoAccountResponseDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/be/src/main/java/com/example/be/oauth/provider/dto/response/LoginResponse.java
+++ b/be/src/main/java/com/example/be/oauth/provider/dto/response/LoginResponse.java
@@ -1,4 +1,4 @@
-package com.example.be.oauth.provider.dto;
+package com.example.be.oauth.provider.dto.response;
 
 import lombok.Getter;
 

--- a/be/src/test/java/com/example/be/oauth/OAuthLoginIntegrationTest.java
+++ b/be/src/test/java/com/example/be/oauth/OAuthLoginIntegrationTest.java
@@ -6,7 +6,7 @@ import com.example.be.core.domain.member.Member;
 import com.example.be.core.repository.member.MemberRepository;
 import com.example.be.oauth.provider.JwtProvider;
 import com.example.be.oauth.provider.LoginService;
-import com.example.be.oauth.provider.dto.LoginResponse;
+import com.example.be.oauth.provider.dto.response.LoginResponse;
 import com.example.be.tool.OAuthMocks;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import java.io.IOException;
@@ -51,7 +51,7 @@ class OAuthLoginIntegrationTest {
 		WireMock.setScenarioState("Kakao Login Success", "Started");
 
 		//when
-		LoginResponse response = loginService.login("code");
+		LoginResponse response = loginService.login("code", Boolean.FALSE);
 		String accessToken = response.getAccessToken();
 		String refreshToken = response.getRefreshToken();
 		Long memberId = response.getMemberId();
@@ -77,7 +77,7 @@ class OAuthLoginIntegrationTest {
 		));
 
 		//when
-		LoginResponse response = loginService.login("code");
+		LoginResponse response = loginService.login("code", Boolean.FALSE);
 		String accessToken = response.getAccessToken();
 		String refreshToken = response.getRefreshToken();
 		Long memberId = response.getMemberId();


### PR DESCRIPTION
### ❗️ 이슈 번호

Closes #89 

<br><br>

### 📝 구현 내용

- APP LOGIN 방식 추가

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- 현재 구현된 방식이 REST API 기준 소셜(카카오) 로그인 제공이었는데, JSON으로 내려준 응답값이 safari browser에 받아지는 현상 때문에 Native APP 방식으로 소셜로그인 방식을 변경하였습니다.
- 아직 기존 REST API 로그인 방식은 남겨두었습니다.(테스트 용도)
- 따라서 추후 통일된 처리를 위해 리팩토링이 필요합니다.
<br><br>
