### PR TITLE
Study Repository 외래키 조회 네이밍 수정

### DIFF
--- a/be/src/main/java/com/example/be/core/application/AssignmentService.java
+++ b/be/src/main/java/com/example/be/core/application/AssignmentService.java
@@ -57,7 +57,7 @@ public class AssignmentService {
             assignmentRequest.getPhoto())
     );
 
-    List<StudyMember> studyMembers = studyMemberRepository.findStudyMembersByStudyId(assignmentRequest.getStudyId());
+    List<StudyMember> studyMembers = studyMemberRepository.findStudyMembersByStudy_Id(assignmentRequest.getStudyId());
 
     studyMembers.forEach(studyMember ->
         assignmentMemberRepository.save(

--- a/be/src/main/java/com/example/be/core/application/StudyService.java
+++ b/be/src/main/java/com/example/be/core/application/StudyService.java
@@ -27,7 +27,6 @@ import com.example.be.core.repository.study.StudyRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.SortedMap;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Sort;
@@ -127,7 +126,7 @@ public class StudyService {
 
     List<Study> studies = studyRepository.findAll();
     List<StudyResponse> studyResponses = studies.stream().map(study -> {
-      Integer memberCount = studyMemberRepository.countStudyMemberByStudyId(study.getId());
+      Integer memberCount = studyMemberRepository.countStudyMemberByStudy_Id(study.getId());
       return new StudyResponse(
           study.getId(),
           study.getTitle(),
@@ -196,7 +195,7 @@ public class StudyService {
   public StudyPreviewsResponse findPreview(Long memberId, StudyPreviewConditionRequest studyPreviewConditionRequest) {
     log.debug("[스터디 미리보기 조회] memberId = {}, StudyPreviewConditionRequest = {}", memberId, studyPreviewConditionRequest);
 
-    List<StudyMember> studyMembers = studyMemberRepository.findStudyMembersByMemberId(memberId);
+    List<StudyMember> studyMembers = studyMemberRepository.findStudyMembersByMember_Id(memberId);
     List<String> memberProfiles = new ArrayList<>();
 
     if (studyPreviewConditionRequest.getType().equals(StudyPreviewType.MY)) {
@@ -225,7 +224,7 @@ public class StudyService {
     List<Study> studies = studyRepository.findAll(Sort.by(Direction.DESC, "createdAt"));
     List<StudyPreviewResponse> randomStudyPreviewResponse = studies.stream().map(study -> {
 
-      List<StudyMember> members = studyMemberRepository.findStudyMembersByStudyId(study.getId());
+      List<StudyMember> members = studyMemberRepository.findStudyMembersByStudy_Id(study.getId());
 
       memberProfiles.clear();
       for (StudyMember member : members) {
@@ -312,7 +311,7 @@ public class StudyService {
   public void delete(Long memberId, Long studyId) {
     log.debug("[스터디 삭제] studyId = {}", studyId);
 
-    StudyMember studyLeader = studyMemberRepository.findStudyMemberByStudyIdAndLeaderIsTrue(studyId);
+    StudyMember studyLeader = studyMemberRepository.findStudyMemberByStudy_IdAndLeaderIsTrue(studyId);
 
     if (!Objects.equals(studyLeader.getMember().getId(), memberId)) {
       throw new NotMatchStudyAndMemberException();
@@ -351,7 +350,7 @@ public class StudyService {
   }
 
   private boolean isStudyInterested(Long loginMemberId, Study study) {
-    return studyInterestRepository.findByMemberIdAndStudy(loginMemberId, study).isPresent();
+    return studyInterestRepository.findByMember_IdAndStudy(loginMemberId, study).isPresent();
   }
 
   private static boolean leaderCheck(Long loginMemberId, boolean isLeader, StudyMember member) {
@@ -367,7 +366,7 @@ public class StudyService {
   }
 
   private List<StudyMember> getStudyMembers(Long studyId) {
-    return studyMemberRepository.findStudyMembersByStudyId(
+    return studyMemberRepository.findStudyMembersByStudy_Id(
         studyId);
   }
 }

--- a/be/src/main/java/com/example/be/core/repository/study/StudyInterestRepository.java
+++ b/be/src/main/java/com/example/be/core/repository/study/StudyInterestRepository.java
@@ -9,7 +9,7 @@ public interface StudyInterestRepository extends JpaRepository<StudyInterest, Lo
 
   Integer countByStudyId(Long studyId);
 
-  Optional<StudyInterest> findByMemberIdAndStudy(Long memberId, Study study);
+  Optional<StudyInterest> findByMember_IdAndStudy(Long memberId, Study study);
 
   void deleteByMemberIdAndStudyId(Long memberId, Long studyId);
 }

--- a/be/src/main/java/com/example/be/core/repository/study/StudyMemberRepository.java
+++ b/be/src/main/java/com/example/be/core/repository/study/StudyMemberRepository.java
@@ -3,14 +3,13 @@ package com.example.be.core.repository.study;
 import com.example.be.core.domain.study.StudyMember;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> {
-    List<StudyMember> findStudyMembersByStudyId(Long studyId);
+    List<StudyMember> findStudyMembersByStudy_Id(Long studyId);
 
-    List<StudyMember> findStudyMembersByMemberId(Long memberId);
+    List<StudyMember> findStudyMembersByMember_Id(Long memberId);
 
-    StudyMember findStudyMemberByStudyIdAndLeaderIsTrue(Long studyId);
+    StudyMember findStudyMemberByStudy_IdAndLeaderIsTrue(Long studyId);
 
-    Integer countStudyMemberByStudyId(Long studyId);
+    Integer countStudyMemberByStudy_Id(Long studyId);
 }

--- a/be/src/test/java/com/example/be/tool/DataBaseConfigurator.java
+++ b/be/src/test/java/com/example/be/tool/DataBaseConfigurator.java
@@ -214,7 +214,7 @@ public class DataBaseConfigurator implements InitializingBean {
 	 */
 	private void initAssignment() {
 		Study study = studyRepository.findById(1L).get();
-		List<StudyMember> studyMembers = studyMemberRepository.findStudyMembersByStudyId(
+		List<StudyMember> studyMembers = studyMemberRepository.findStudyMembersByStudy_Id(
 			study.getId());
 		for (int i = 1; i <= NUMBER_OF_ASSIGNMENT; i++) {
 			Assignment assignment = assignmentRepository.save(


### PR DESCRIPTION
### ❗️ 이슈 번호

Closes #107 

<br><br>

### 📝 구현 내용

- Study 관련 Repository 외래키 조회 네이밍 수정했습니다.
findBy + (FK를 관리하는 Entity의 필드명에서 첫 글자를 대문자) + _ + (FK Entity의 식별자 필드명에서 첫 글자를 대문자)
<br><br>

<img width="767" alt="image" src="https://user-images.githubusercontent.com/49313910/222625515-c9499568-b215-4c9b-a7cb-238e6e39c157.png">

<img width="578" alt="image" src="https://user-images.githubusercontent.com/49313910/222625578-7ee8d7e5-e75a-4b51-8e90-f10cd6796a9d.png">


### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- 현재 Study관련 작업을 하기 위해 Study 관련 Repository만 수정했습니다. 
맡은 부분에 대한 Repository 수정 부탁드립니다.
<br><br>

### 💡 참고 자료

- https://pooney.tistory.com/83
